### PR TITLE
Fix Backward timer control button while song is playing 

### DIFF
--- a/src/components/TimerControls.tsx
+++ b/src/components/TimerControls.tsx
@@ -15,7 +15,7 @@ export default observer(function TimerControls() {
         height={6}
         icon={<FaStepBackward size={10} />}
         onClick={action(() => {
-          timer.globalTime = 0;
+          timer.setTime(0);
         })}
       />
       <IconButton

--- a/src/components/Waveform.tsx
+++ b/src/components/Waveform.tsx
@@ -64,7 +64,7 @@ export default observer(function Waveform() {
       const progress = duration > 0 ? timer.lastCursorPosition / wavesurferRef.current.getDuration() : 0;
       wavesurferRef.current.seekTo(progress);
     }
-  }, [timer.lastCursorPosition, timer._lastStartedAtDateTime]);
+  }, [timer.lastCursorPosition]);
 
   return (
     <Box position="absolute" top={1.5} width="100%">

--- a/src/components/Waveform.tsx
+++ b/src/components/Waveform.tsx
@@ -61,10 +61,10 @@ export default observer(function Waveform() {
   useEffect(() => {
     if (wavesurferRef.current) {
       const progress =
-        timer.lastCursorPosition / wavesurferRef.current.getDuration();
+        timer.globalTime / wavesurferRef.current.getDuration();
       wavesurferRef.current.seekTo(progress);
     }
-  }, [timer.lastCursorPosition]);
+  }, [timer.globalTime]);
 
   return (
     <Box position="absolute" top={1.5} width="100%">

--- a/src/components/Waveform.tsx
+++ b/src/components/Waveform.tsx
@@ -60,8 +60,8 @@ export default observer(function Waveform() {
 
   useEffect(() => {
     if (wavesurferRef.current) {
-      const progress =
-        timer.globalTime / wavesurferRef.current.getDuration();
+      const duration = wavesurferRef.current.getDuration();
+      const progress = duration > 0 ? timer.globalTime / wavesurferRef.current.getDuration() : 0;
       wavesurferRef.current.seekTo(progress);
     }
   }, [timer.globalTime]);

--- a/src/components/Waveform.tsx
+++ b/src/components/Waveform.tsx
@@ -61,10 +61,10 @@ export default observer(function Waveform() {
   useEffect(() => {
     if (wavesurferRef.current) {
       const duration = wavesurferRef.current.getDuration();
-      const progress = duration > 0 ? timer.globalTime / wavesurferRef.current.getDuration() : 0;
+      const progress = duration > 0 ? timer.lastCursorPosition / wavesurferRef.current.getDuration() : 0;
       wavesurferRef.current.seekTo(progress);
     }
-  }, [timer.globalTime]);
+  }, [timer.lastCursorPosition, timer._lastStartedAtDateTime]);
 
   return (
     <Box position="absolute" top={1.5} width="100%">

--- a/src/types/Timer.ts
+++ b/src/types/Timer.ts
@@ -1,5 +1,5 @@
 import { FRAMES_PER_SECOND, MAX_TIME } from "@/src/utils/time";
-import { makeAutoObservable, reaction, runInAction } from "mobx";
+import { makeAutoObservable, runInAction } from "mobx";
 
 export default class Timer {
   _lastStartedAtDateTime = 0;

--- a/src/types/Timer.ts
+++ b/src/types/Timer.ts
@@ -1,5 +1,5 @@
 import { FRAMES_PER_SECOND, MAX_TIME } from "@/src/utils/time";
-import { makeAutoObservable, runInAction } from "mobx";
+import { makeAutoObservable, reaction, runInAction } from "mobx";
 
 export default class Timer {
   _lastStartedAtDateTime = 0;


### PR DESCRIPTION
Before, clicking the Backward button while the song was playing would not actually make it restart the song.

Also, the progress display on the waveform wouldn't reset. I wasn't really sure why that was the case since it seems like lastCursorPosition should have been enough, but maybe globalTime might make more sense for calculating progress anyhow.

See in screenshot below that the progress got into a weird state (the blue part of the waveform is past the red arrow).

![Screenshot 2023-04-12 at 6 45 38 PM](https://user-images.githubusercontent.com/287116/231624862-d9fc5701-0ef1-43a2-86b9-dbab8a3e821e.png)
