### PR TITLE
Timeline ruler cursor drag

### DIFF
--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -62,7 +62,7 @@ export default observer(function Timeline() {
           onMouseDown={action((e) => {
             rulerDrag(e.nativeEvent);
             window.addEventListener('mousemove', rulerDrag);
-            window.addEventListener('mouseup', ()=>window.removeEventListener('mousemove', rulerDrag));
+            window.addEventListener('mouseup', () => window.removeEventListener('mousemove', rulerDrag), { once: true });
           })}
         >
           <Waveform />

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -22,9 +22,10 @@ export default observer(function Timeline() {
   const rulerDrag = action((e: MouseEvent) => {
     if (rulerBoxRef.current)
       timer.setTime(
-        uiStore.xToTime(
-          e.clientX - rulerBoxRef.current.getBoundingClientRect().x,
-        ),
+        Math.max(0,
+          uiStore.xToTime(
+            e.clientX - rulerBoxRef.current.getBoundingClientRect().x,
+          )),
       );
   })
 

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -19,6 +19,15 @@ export default observer(function Timeline() {
 
   useWheelZooming(gridRef.current);
 
+  const rulerDrag = action((e: MouseEvent) => {
+    if (rulerBoxRef.current)
+      timer.setTime(
+        uiStore.xToTime(
+          e.clientX - rulerBoxRef.current.getBoundingClientRect().x,
+        ),
+      );
+  })
+
   return (
     <Grid
       ref={gridRef}
@@ -50,13 +59,10 @@ export default observer(function Timeline() {
           position="relative"
           height={10}
           bgColor="gray.500"
-          onClick={action((e) => {
-            if (rulerBoxRef.current)
-              timer.setTime(
-                uiStore.xToTime(
-                  e.clientX - rulerBoxRef.current.getBoundingClientRect().x,
-                ),
-              );
+          onMouseDown={action((e) => {
+            rulerDrag(e.nativeEvent);
+            window.addEventListener('mousemove', rulerDrag);
+            window.addEventListener('mouseup', ()=>window.removeEventListener('mousemove', rulerDrag));
           })}
         >
           <Waveform />


### PR DESCRIPTION
(WARNING: includes commits from #12 and has that branch as merge base. Change merge base before merging!)

This lets your drag around the timeline cursor with the mouse, which is more satisfying to my brain than updating on click :P

I didn't do it in a very "react-y" way, but I wasn't exactly sure how best to do that while supporting drag events from outside the timeline ruler element.