### PR TITLE
Make sure that changes to lastCursor are always observable

### DIFF
--- a/src/components/TimerControls.tsx
+++ b/src/components/TimerControls.tsx
@@ -14,9 +14,7 @@ export default observer(function TimerControls() {
         aria-label="Backward"
         height={6}
         icon={<FaStepBackward size={10} />}
-        onClick={action(() => {
-          timer.setTime(0);
-        })}
+        onClick={action(() => timer.setTime(0))}
       />
       <IconButton
         aria-label="Play"
@@ -30,7 +28,7 @@ export default observer(function TimerControls() {
         height={6}
         icon={<FaStepForward size={10} />}
         onClick={action(() => {
-          timer.globalTime = MAX_TIME;
+          timer.setTime(MAX_TIME);
           timer.playing = false;
         })}
       />

--- a/src/components/Waveform.tsx
+++ b/src/components/Waveform.tsx
@@ -61,10 +61,10 @@ export default observer(function Waveform() {
   useEffect(() => {
     if (wavesurferRef.current) {
       const duration = wavesurferRef.current.getDuration();
-      const progress = duration > 0 ? timer.lastCursorPosition / wavesurferRef.current.getDuration() : 0;
+      const progress = duration > 0 ? timer.lastCursor.position / duration : 0;
       wavesurferRef.current.seekTo(progress);
     }
-  }, [timer.lastCursorPosition]);
+  }, [timer.lastCursor.position]);
 
   return (
     <Box position="absolute" top={1.5} width="100%">

--- a/src/types/Timer.ts
+++ b/src/types/Timer.ts
@@ -2,9 +2,9 @@ import { FRAMES_PER_SECOND, MAX_TIME } from "@/src/utils/time";
 import { makeAutoObservable, runInAction } from "mobx";
 
 export default class Timer {
-  _lastStartedAtDateTime = 0;
-  _globalTime = 0;
-  _lastCursorPosition = 0;
+  private _lastStartedAtDateTime = 0;
+  private _globalTime = 0;
+  private _lastCursor = { position: 0 };
 
   playing = false;
 
@@ -16,12 +16,23 @@ export default class Timer {
     this._globalTime = time < 0 ? 0 : time;
   }
 
+  /**
+   * The last cursor position that was set by the user. This is listenable/observable, since it is and object and not a primitive.
+   *
+   * @readonly
+   * @memberof Timer
+   */
+  get lastCursor() {
+    return this._lastCursor;
+  }
+
   get lastCursorPosition() {
-    return this._lastCursorPosition;
+    return this._lastCursor.position;
   }
 
   set lastCursorPosition(time: number) {
-    this._lastCursorPosition = time < 0 ? 0 : time;
+    // instantiate a new object here to trigger Mobx reactions
+    this._lastCursor = { position: time < 0 ? 0 : time };
   }
 
   constructor() {
@@ -39,7 +50,7 @@ export default class Timer {
 
     if (this.playing) {
       this._lastStartedAtDateTime = Date.now();
-      this.lastCursorPosition = this._globalTime;
+      this.lastCursorPosition = this.globalTime;
     }
   };
 


### PR DESCRIPTION
Weird Mobx learning here: made lastCursor a reference such that it can cause reactions even when the underlying primitive isn't changed.