### PR TITLE
points perspective

### DIFF
--- a/src/patterns/shaders/canopy.vert
+++ b/src/patterns/shaders/canopy.vert
@@ -9,16 +9,14 @@ varying float v_intensity;
 
 
 void main() {
-    gl_PointSize = 4.0;
-
     // Pass the intensity to the fragment shader.
 
     // The object normal should be multiplied by the normalMatrix
     vec3 pixelNormal = normalize(normalMatrix * normal);
     // The object-to-camera vector projects the object position by the view matrix, then takes the difference from the view vector
-    vec3 cameraToPixelVector = normalize((modelViewMatrix * vec4(position, 1.0)).xyz - u_view_vector);
+    vec3 cameraToPixelVector = (modelViewMatrix * vec4(position, 1.0)).xyz - u_view_vector;
     // The dot product gives us a measure of how close the normal is to facing the camera
-    float normalizedItensity = 1. - dot(pixelNormal, cameraToPixelVector);
+    float normalizedItensity = 1. - dot(pixelNormal, normalize(cameraToPixelVector));
     // The intensity should decay faster off-angle than a simple dot product, hence the square
     float adjustedIntensity = pow(normalizedItensity, 2.0);
     // Drop to a minimum intensity below the blackout lower bound, and rise to max intensity above the fullbright lower bound
@@ -32,4 +30,5 @@ void main() {
     v_uv = uv;
 
     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    gl_PointSize = 100.0 / length(cameraToPixelVector);
 }


### PR DESCRIPTION
With this change, the canopy vertex shader updates `gl_PointSize` based on the size of vector between gl point and camera.

# Before 

<img width="481" alt="Screen Shot 2023-05-12 at 8 33 29 PM" src="https://github.com/SotSF/conjurer/assets/287116/edaecb1a-07e8-4d4a-836a-6ff493a74ee0">

# After
<img width="404" alt="Screen Shot 2023-05-12 at 8 33 52 PM" src="https://github.com/SotSF/conjurer/assets/287116/4e05f6ab-3363-4238-9616-b79972745e97">

