### PR TITLE
UI fixes / showing off the new pulse pattern

### DIFF
--- a/src/components/VariationControls.tsx
+++ b/src/components/VariationControls.tsx
@@ -7,10 +7,11 @@ import {
   NumberInput,
   NumberInputField,
   NumberInputStepper,
+  Switch,
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { useState } from "react";
+import { ChangeEvent, useState } from "react";
 import { Variation } from "@/src/types/Variations/Variation";
 import { action } from "mobx";
 import { FaTrashAlt } from "react-icons/fa";
@@ -269,28 +270,112 @@ function SineVariationControls({
   const [phase, setPhase] = useState(variation.phase.toString());
   const [offset, setOffset] = useState(variation.offset.toString());
 
+  const [min, setMin] = useState(variation.min.toString());
+  const [max, setMax] = useState(variation.max.toString());
+
+  const [showingMinMax, setShowingMinMax] = useState(true);
+
   return (
     <>
       <Text>Sine</Text>
       <HStack m={1}>
-        <Text>Amplitude:</Text>
-        <NumberInput
-          size="md"
-          step={0.1}
-          onChange={(valueString) => {
-            variation.amplitude = parseFloat(valueString);
-            setAmplitude(valueString);
-            block.triggerVariationReactions(uniformName);
+        <Text>Min/max mode:</Text>
+        <Switch
+          m={1}
+          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            setShowingMinMax(event.target.checked);
+            // re sync the min/max/amplitude/offset
+            setAmplitude(variation.amplitude.toString());
+            setOffset(variation.offset.toString());
+            setMin(variation.min.toString());
+            setMax(variation.max.toString());
           }}
-          value={amplitude}
-        >
-          <NumberInputField />
-          <NumberInputStepper>
-            <NumberIncrementStepper />
-            <NumberDecrementStepper />
-          </NumberInputStepper>
-        </NumberInput>
+          isChecked={showingMinMax}
+        />
       </HStack>
+      {showingMinMax ? (
+        <>
+          <HStack m={1}>
+            <Text>Min:</Text>
+            <NumberInput
+              size="md"
+              step={0.1}
+              onChange={(valueString) => {
+                variation.min = parseFloat(valueString);
+                setMin(valueString);
+                block.triggerVariationReactions(uniformName);
+              }}
+              value={min}
+            >
+              <NumberInputField />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
+          </HStack>
+          <HStack m={1}>
+            <Text>Max:</Text>
+            <NumberInput
+              size="md"
+              step={0.1}
+              onChange={(valueString) => {
+                variation.max = parseFloat(valueString);
+                setMax(valueString);
+                block.triggerVariationReactions(uniformName);
+              }}
+              value={max}
+            >
+              <NumberInputField />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
+          </HStack>
+        </>
+      ) : (
+        <>
+          <HStack m={1}>
+            <Text>Offset:</Text>
+            <NumberInput
+              size="md"
+              step={0.1}
+              onChange={(valueString) => {
+                variation.offset = parseFloat(valueString);
+                setOffset(valueString);
+                block.triggerVariationReactions(uniformName);
+              }}
+              value={offset}
+            >
+              <NumberInputField />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
+          </HStack>
+          <HStack m={1}>
+            <Text>Amplitude:</Text>
+            <NumberInput
+              size="md"
+              step={0.1}
+              onChange={(valueString) => {
+                variation.amplitude = parseFloat(valueString);
+                setAmplitude(valueString);
+                block.triggerVariationReactions(uniformName);
+              }}
+              value={amplitude}
+            >
+              <NumberInputField />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
+          </HStack>
+        </>
+      )}
       <HStack m={1}>
         <Text>Frequency:</Text>
         <NumberInput
@@ -321,25 +406,6 @@ function SineVariationControls({
             block.triggerVariationReactions(uniformName);
           }}
           value={phase}
-        >
-          <NumberInputField />
-          <NumberInputStepper>
-            <NumberIncrementStepper />
-            <NumberDecrementStepper />
-          </NumberInputStepper>
-        </NumberInput>
-      </HStack>
-      <HStack m={1}>
-        <Text>Offset:</Text>
-        <NumberInput
-          size="md"
-          step={0.1}
-          onChange={(valueString) => {
-            variation.offset = parseFloat(valueString);
-            setOffset(valueString);
-            block.triggerVariationReactions(uniformName);
-          }}
-          value={offset}
         >
           <NumberInputField />
           <NumberInputStepper>

--- a/src/components/VariationGraph/ScalarVariationGraph.tsx
+++ b/src/components/VariationGraph/ScalarVariationGraph.tsx
@@ -52,7 +52,8 @@ export const ScalarVariationGraph = memo(function ScalarVariationGraph({
           stroke={orange}
           yAxisId={0}
         />
-        <Tooltip isAnimationActive={false} content={<ScalarValueTooltip />} />
+        {/* Unfortunately this Tooltip is messing with the popover component... */}
+        {/* <Tooltip isAnimationActive={false} content={<ScalarValueTooltip />} /> */}
         <YAxis type="number" domain={domain} hide allowDataOverflow={false} />
       </LineChart>
     </Box>

--- a/src/components/VariationGraph/VariationGraph.tsx
+++ b/src/components/VariationGraph/VariationGraph.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Popover,
+  PopoverArrow,
   PopoverContent,
   PopoverTrigger,
   Portal,
@@ -62,6 +63,7 @@ export const VariationGraph = function VariationGraph({
       </PopoverTrigger>
       <Portal>
         <PopoverContent>
+          <PopoverArrow />
           <VariationControls
             variation={variation}
             uniformName={uniformName}

--- a/src/data/initialExperience.json
+++ b/src/data/initialExperience.json
@@ -4,21 +4,22 @@
   },
   "blocks": [
     {
-      "pattern": "Barcode",
+      "pattern": "Pulse",
       "startTime": 0,
       "duration": 38,
       "parameterVariations": {
-        "u_saturation_start": [
-          { "type": "flat", "duration": 2, "value": 0 },
-          { "type": "linear", "duration": 36, "from": 0, "to": 1 }
-        ],
-        "u_hue_start": [{ "type": "flat", "duration": 2, "value": 0 }],
-        "u_hue_width": [
-          { "type": "flat", "duration": 2, "value": 0 },
-          { "type": "linear", "duration": 36, "from": 0, "to": 1 }
-        ]
+        "u_wave_amplitude": [{ "type": "flat", "duration": 2, "value": 0.4 }],
+        "u_wave_period": [{ "type": "flat", "duration": 2, "value": 0.125 }]
       },
-      "effectBlocks": []
+      "effectBlocks": [
+        {
+          "pattern": "Rotate",
+          "startTime": 0,
+          "duration": 5,
+          "parameterVariations": {},
+          "effectBlocks": []
+        }
+      ]
     },
     {
       "pattern": "Clouds",
@@ -158,12 +159,36 @@
           "effectBlocks": []
         }
       ]
+    },
+    {
+      "pattern": "Barcode",
+      "startTime": 148.75,
+      "duration": 38,
+      "parameterVariations": {
+        "u_saturation_start": [
+          { "type": "flat", "duration": 2, "value": 0 },
+          { "type": "linear", "duration": 36, "from": 0, "to": 1 }
+        ],
+        "u_hue_start": [{ "type": "flat", "duration": 2, "value": 0 }],
+        "u_hue_width": [
+          { "type": "flat", "duration": 2, "value": 0 },
+          {
+            "type": "sine",
+            "duration": 19.25,
+            "amplitude": 0.7,
+            "frequency": 0.5,
+            "phase": 0,
+            "offset": 1
+          }
+        ]
+      },
+      "effectBlocks": []
     }
   ],
   "uiStore": {
     "showingPerformance": false,
     "displayingCanopy": true,
-    "pixelsPerSecond": 32,
+    "pixelsPerSecond": 38,
     "beatLength": 1
   },
   "user": ""

--- a/src/patterns/Disc.ts
+++ b/src/patterns/Disc.ts
@@ -6,7 +6,6 @@ export const Disc = () => {
   const params = {
     u_color: {
       name: "Color",
-
       value: new Vector4(1, 1, 1, 1),
     },
     u_radius: {

--- a/src/patterns/Pulse.ts
+++ b/src/patterns/Pulse.ts
@@ -2,6 +2,39 @@ import { Pattern } from "@/src/types/Pattern";
 import pulse from "./shaders/pulse.frag";
 
 export const Pulse = () => {
-  const params = {};
+  const params = {
+    u_hue_start: {
+      name: "Hue Start",
+      value: 0,
+    },
+    u_hue_width: {
+      name: "Hue Width",
+      value: 0.8,
+    },
+    u_duty_cycle: {
+      name: "Duty Cycle",
+      value: 0.5,
+    },
+    u_time_factor: {
+      name: "Time Factor",
+      value: 0.4,
+    },
+    u_time_offset: {
+      name: "Time Offset",
+      value: 0,
+    },
+    u_wave_period: {
+      name: "Wave Period",
+      value: 0.25,
+    },
+    u_wave_amplitude: {
+      name: "Wave Amplitude",
+      value: 0,
+    },
+    u_number_colors: {
+      name: "Number of Colors",
+      value: 4,
+    },
+  };
   return new Pattern<typeof params>("Pulse", pulse, params);
 };

--- a/src/patterns/shaders/pulse.frag
+++ b/src/patterns/shaders/pulse.frag
@@ -7,28 +7,23 @@ precision mediump float;
 
 #define PI 3.14159265358979323846
 
-uniform float u_segments;
-uniform float u_stutter_frequency;
-uniform float u_go_nuts;
-uniform float u_saturation_start;
 uniform float u_hue_start;
 uniform float u_hue_width;
+uniform float u_duty_cycle;
+uniform float u_time_factor;
+uniform float u_time_offset;
+uniform float u_wave_period;
+uniform float u_wave_amplitude;
+uniform float u_number_colors;
 
-// #define u_segments 4.5
-// #define u_stutter_frequency .8
-// #define u_go_nuts 0.0
-// #define u_saturation_start 1.0
-
-#define u_pulses .
-#define u_hue_start 0.
-#define u_hue_width 0.8
-
-#define u_duty_cycle .5
-#define u_time_factor 0.4
-#define u_time_offset 0.0
-#define u_wave_period 1.
-#define u_wave_amplitude 0.0
-#define u_number_colors 5.
+// #define u_hue_start 0.
+// #define u_hue_width 0.8
+// #define u_duty_cycle .5
+// #define u_time_factor 0.4
+// #define u_time_offset 0.0
+// #define u_wave_period 1.
+// #define u_wave_amplitude 0.0
+// #define u_number_colors 5.
 
 uniform vec2 u_resolution;
 uniform float u_time;

--- a/src/types/Variations/SineVariation.ts
+++ b/src/types/Variations/SineVariation.ts
@@ -6,6 +6,26 @@ export class SineVariation extends Variation<number> {
   phase: number;
   offset: number;
 
+  get min() {
+    return -this.amplitude + this.offset;
+  }
+
+  set min(newMin: number) {
+    const oldMax = this.max;
+    this.amplitude = (oldMax - newMin) / 2;
+    this.offset = newMin + this.amplitude;
+  }
+
+  get max() {
+    return this.amplitude + this.offset;
+  }
+
+  set max(newMax: number) {
+    const oldMin = this.min;
+    this.amplitude = (newMax - oldMin) / 2;
+    this.offset = oldMin + this.amplitude;
+  }
+
   constructor(
     duration: number,
     amplitude: number,


### PR DESCRIPTION
it can do cool things
![image](https://github.com/SotSF/conjurer/assets/12655228/bb4e8b6b-219a-4e9f-8eb2-0b27a8b5123e)

Also removed the recharts tooltip which was interfering with the normal chakra popover component behavior. Also implemented min/max for sine variations!
![Screen Shot 2023-05-12 at 9 16 15 PM](https://github.com/SotSF/conjurer/assets/12655228/8baca4bb-ecab-4362-9aeb-85bdaca60cd3)
