### PR TITLE
Conjurer common

### DIFF
--- a/src/components/Canopy.tsx
+++ b/src/components/Canopy.tsx
@@ -9,7 +9,6 @@ import { useFrame, useThree } from "@react-three/fiber";
 import { useEffect, useMemo, useRef } from "react";
 import canopyVert from "@/src/shaders/canopy.vert";
 import fromTextureWithIntensity from "@/src/shaders/fromTextureWithIntensity.frag";
-import conjurerCommon from "@/src/shaders/conjurer_common.frag";
 import canopyGeometry from "@/src/data/canopyGeometry.json";
 import {
   BloomEffect,
@@ -56,9 +55,6 @@ export const Canopy = function Canopy({ renderTarget }: CanopyViewProps) {
       gl.domElement.clientWidth,
       gl.domElement.clientHeight
     );
-
-    // This enables `#include <conjurer_common>`
-    ShaderChunk.conjurer_common = conjurerCommon;
 
     return effectComposer;
   }, [gl]);

--- a/src/components/Canopy.tsx
+++ b/src/components/Canopy.tsx
@@ -3,11 +3,13 @@ import {
   BufferGeometry,
   Scene,
   WebGLRenderTarget,
+  ShaderChunk,
 } from "three";
 import { useFrame, useThree } from "@react-three/fiber";
 import { useEffect, useMemo, useRef } from "react";
 import canopyVert from "@/src/shaders/canopy.vert";
 import fromTextureWithIntensity from "@/src/shaders/fromTextureWithIntensity.frag";
+import conjurerCommon from "@/src/shaders/conjurer_common.frag";
 import canopyGeometry from "@/src/data/canopyGeometry.json";
 import {
   BloomEffect,
@@ -54,6 +56,10 @@ export const Canopy = function Canopy({ renderTarget }: CanopyViewProps) {
       gl.domElement.clientWidth,
       gl.domElement.clientHeight
     );
+
+    // This enables `#include <conjurer_common>`
+    ShaderChunk.conjurer_common = conjurerCommon;
+
     return effectComposer;
   }, [gl]);
 

--- a/src/components/DisplayCanvas.tsx
+++ b/src/components/DisplayCanvas.tsx
@@ -6,9 +6,18 @@ import { useStore } from "@/src/types/StoreContext";
 import { RenderPipeline } from "@/src/components/RenderPipeline/RenderPipeline";
 import { CartesianView } from "@/src/components/CartesianView";
 import { CameraControls } from "@/src/components/CameraControls";
+import { useEffect } from "react";
+
+import { ShaderChunk } from "three";
+import conjurerCommon from "@/src/shaders/conjurer_common.frag";
 
 export const DisplayCanvas = observer(function DisplayCanvas() {
   const { uiStore } = useStore();
+
+  useEffect(() => {
+    // This enables `#include <conjurer_common>`
+    ShaderChunk.conjurer_common = conjurerCommon;
+  }, []);
 
   return (
     <Canvas

--- a/src/patterns/shaders/starfield.frag
+++ b/src/patterns/shaders/starfield.frag
@@ -4,6 +4,8 @@
 // License URL: http://creativecommons.org/licenses/by-nc-sa/3.0/
 // Source: https://www.shadertoy.com/view/MtKBWw
 
+#include <conjurer_common>
+
 #ifdef GL_ES
 precision mediump float;
 #endif
@@ -25,16 +27,6 @@ uniform float u_intensity;
 uniform vec2 u_resolution;
 uniform float u_time;
 varying vec2 v_uv;
-
-vec3 hsv(float h, float s, float v) {
-    vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-    vec3 p = abs(fract(vec3(h) + K.xyz) * 6.0 - K.www);
-    return v * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), s);
-}
-
-float rand(vec2 co) {
-    return fract(sin(dot(co.xy, vec2(12.9898, 78.233))) * 43758.5453);
-}
 
 void main() {
     // vec2 st = (2.0 * gl_FragCoord.xy - u_resolution.xy) / min(u_resolution.x, u_resolution.y);

--- a/src/shaders/conjurer_common.frag
+++ b/src/shaders/conjurer_common.frag
@@ -1,0 +1,11 @@
+// START conjurer_common
+float rand(vec2 co) {
+      return fract(sin(dot(co.xy, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+vec3 hsv(float h, float s, float v) {
+    vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+    vec3 p = abs(fract(vec3(h) + K.xyz) * 6.0 - K.www);
+    return v * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), s);
+}
+// END conjurer_common

--- a/src/shaders/conjurer_common.frag
+++ b/src/shaders/conjurer_common.frag
@@ -1,3 +1,5 @@
+#ifndef conjurer_common_included
+#define conjurer_common_included
 // START conjurer_common
 float rand(vec2 co) {
       return fract(sin(dot(co.xy, vec2(12.9898, 78.233))) * 43758.5453);
@@ -9,3 +11,4 @@ vec3 hsv(float h, float s, float v) {
     return v * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), s);
 }
 // END conjurer_common
+#endif


### PR DESCRIPTION
This PR adds a ShaderChunk, which then becomes available for pattern artists to include common code with the `#include <conjurer_common>` directive.

Hopefully this way we can provide some useful stuff in there and reduce code duplication across patterns.