### PR TITLE
Header repeat for wide blocks

### DIFF
--- a/src/components/AddEffectButton.tsx
+++ b/src/components/AddEffectButton.tsx
@@ -33,7 +33,13 @@ export const AddEffectButton = observer(function AddEffectButton({
       borderStyle="solid"
     >
       <Menu placement="bottom">
-        <MenuButton as={Button} variant="ghost" width="100%" textAlign="center">
+        <MenuButton
+          as={Button}
+          variant="ghost"
+          width="100%"
+          textAlign="center"
+          px={0}
+        >
           <HStack
             userSelect="none"
             textOverflow="clip"

--- a/src/components/AddEffectButton.tsx
+++ b/src/components/AddEffectButton.tsx
@@ -13,15 +13,15 @@ import {
 import { action } from "mobx";
 import { FiPlusSquare } from "react-icons/fi";
 import { effects } from "@/src/effects/effects";
-import { memo } from "react";
 import { HeaderRepeat } from "@/src/components/HeaderRepeat";
+import { observer } from "mobx-react-lite";
 
 type Props = {
   block: Block;
   isSelected: boolean;
 };
 
-export const AddEffectButton = memo(function AddEffectButton({
+export const AddEffectButton = observer(function AddEffectButton({
   block,
   isSelected,
 }: Props) {
@@ -40,7 +40,7 @@ export const AddEffectButton = memo(function AddEffectButton({
             overflowWrap="anywhere"
             justify="space-evenly"
           >
-            <HeaderRepeat times={2}>
+            <HeaderRepeat times={block.headerRepetitions}>
               <FiPlusSquare size={20} />
               <Text
                 userSelect="none"

--- a/src/components/AddEffectButton.tsx
+++ b/src/components/AddEffectButton.tsx
@@ -14,6 +14,7 @@ import { action } from "mobx";
 import { FiPlusSquare } from "react-icons/fi";
 import { effects } from "@/src/effects/effects";
 import { memo } from "react";
+import { HeaderRepeat } from "@/src/components/HeaderRepeat";
 
 type Props = {
   block: Block;
@@ -37,12 +38,18 @@ export const AddEffectButton = memo(function AddEffectButton({
             userSelect="none"
             textOverflow="clip"
             overflowWrap="anywhere"
-            justify="center"
+            justify="space-evenly"
           >
-            <FiPlusSquare size={20} />
-            <Text userSelect="none" textOverflow="clip" overflowWrap="anywhere">
-              Add effect
-            </Text>
+            <HeaderRepeat times={2}>
+              <FiPlusSquare size={20} />
+              <Text
+                userSelect="none"
+                textOverflow="clip"
+                overflowWrap="anywhere"
+              >
+                Add effect
+              </Text>
+            </HeaderRepeat>
           </HStack>
         </MenuButton>
         <Portal>

--- a/src/components/HeaderRepeat.tsx
+++ b/src/components/HeaderRepeat.tsx
@@ -1,0 +1,20 @@
+import { HStack } from "@chakra-ui/react";
+import { memo } from "react";
+
+export const HeaderRepeat = memo(function HeaderRepeat({
+  times,
+  children,
+}: {
+  times: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      {Array.from({ length: times }).map((_, i) => (
+        <HStack key={i} justify="center" spacing={0}>
+          {children}
+        </HStack>
+      ))}
+    </>
+  );
+});

--- a/src/components/HeaderRepeat.tsx
+++ b/src/components/HeaderRepeat.tsx
@@ -11,7 +11,7 @@ export const HeaderRepeat = memo(function HeaderRepeat({
   return (
     <>
       {Array.from({ length: times }).map((_, i) => (
-        <HStack key={i} justify="center" spacing={0}>
+        <HStack key={i} justify="center" spacing={0} flexGrow={1}>
           {children}
         </HStack>
       ))}

--- a/src/components/ParameterView.tsx
+++ b/src/components/ParameterView.tsx
@@ -8,6 +8,7 @@ import { ParameterVariations } from "@/src/components/ParameterVariations";
 import { observer } from "mobx-react-lite";
 import { ParameterValue } from "@/src/components/ParameterValue";
 import { useStore } from "@/src/types/StoreContext";
+import { HeaderRepeat } from "@/src/components/HeaderRepeat";
 
 type ParameterProps = {
   uniformName: string;
@@ -52,27 +53,29 @@ export const ParameterView = observer(function ParameterView({
         p={0}
         onClick={() => setExpanded(!isExpanded)}
       >
-        <HStack width="100%" justify="center">
-          <Text
-            lineHeight={1}
-            userSelect="none"
-            fontSize={14}
-            color={headerColor}
-          >
-            {patternParam.name}
-            {isCurrentBlock && (
-              <ParameterValue
-                uniformName={uniformName}
-                patternParam={patternParam}
-                block={block}
-              />
+        <HStack width="100%" justify="space-evenly">
+          <HeaderRepeat times={2}>
+            <Text
+              lineHeight={1}
+              userSelect="none"
+              fontSize={14}
+              color={headerColor}
+            >
+              {patternParam.name}
+              {isCurrentBlock && (
+                <ParameterValue
+                  uniformName={uniformName}
+                  patternParam={patternParam}
+                  block={block}
+                />
+              )}
+            </Text>
+            {isExpanded ? (
+              <BsCaretUp key={headerColor} size={10} color={headerColor} />
+            ) : (
+              <BsCaretDown key={headerColor} size={10} color={headerColor} />
             )}
-          </Text>
-          {isExpanded ? (
-            <BsCaretUp key={headerColor} size={10} color={headerColor} />
-          ) : (
-            <BsCaretDown key={headerColor} size={10} color={headerColor} />
-          )}
+          </HeaderRepeat>
         </HStack>
       </Button>
 

--- a/src/components/ParameterView.tsx
+++ b/src/components/ParameterView.tsx
@@ -54,7 +54,7 @@ export const ParameterView = observer(function ParameterView({
         onClick={() => setExpanded(!isExpanded)}
       >
         <HStack width="100%" justify="space-evenly">
-          <HeaderRepeat times={2}>
+          <HeaderRepeat times={block.headerRepetitions}>
             <Text
               lineHeight={1}
               userSelect="none"

--- a/src/components/PatternOrEffectBlock.tsx
+++ b/src/components/PatternOrEffectBlock.tsx
@@ -50,7 +50,7 @@ export const PatternOrEffectBlock = observer(function PatternOrEffectBlock({
         role="button"
         onClick={handleBlockClick}
       >
-        <HeaderRepeat times={2}>
+        <HeaderRepeat times={block.headerRepetitions}>
           {!isEffect && <MdDragIndicator size={30} />}
           <Heading
             size="md"

--- a/src/components/PatternOrEffectBlock.tsx
+++ b/src/components/PatternOrEffectBlock.tsx
@@ -8,6 +8,7 @@ import { BsArrowsCollapse, BsArrowsExpand } from "react-icons/bs";
 import { ParametersList } from "@/src/components/ParametersList";
 import { RxCaretDown, RxCaretUp } from "react-icons/rx";
 import { FaTrashAlt } from "react-icons/fa";
+import { HeaderRepeat } from "@/src/components/HeaderRepeat";
 
 type Props = {
   block: Block;
@@ -42,78 +43,84 @@ export const PatternOrEffectBlock = observer(function PatternOrEffectBlock({
         borderColor={color}
         borderStyle="solid"
         className={isEffect ? "" : "handle"}
-        justify="center"
+        justify="space-evenly"
         cursor={isEffect ? "pointer" : "grab"}
         spacing={0}
         color={color}
         role="button"
         onClick={handleBlockClick}
       >
-        {!isEffect && <MdDragIndicator size={30} />}
-        <Heading
-          size="md"
-          userSelect="none"
-          textOverflow="clip"
-          overflowWrap="anywhere"
-          color={color}
-        >
-          {isEffect ? "Effect" : "Pattern"}: {block.pattern.name}
-        </Heading>
-        <IconButton
-          variant="ghost"
-          size="xs"
-          aria-label="Flat"
-          title="Flat"
-          height={6}
-          icon={
-            expandMode === "collapsed" ? (
-              <BsArrowsExpand size={15} />
-            ) : (
-              <BsArrowsCollapse size={15} />
-            )
-          }
-          onClick={(e) => {
-            setExpandMode(expandMode === "expanded" ? "collapsed" : "expanded");
-            e.stopPropagation();
-          }}
-        />
-        {isEffect && (
-          <HStack position="absolute" right={0}>
-            {effectIndex < lastEffectIndex && (
+        <HeaderRepeat times={2}>
+          {!isEffect && <MdDragIndicator size={30} />}
+          <Heading
+            size="md"
+            userSelect="none"
+            textOverflow="clip"
+            overflowWrap="anywhere"
+            color={color}
+          >
+            {isEffect ? "Effect" : "Pattern"}: {block.pattern.name}
+          </Heading>
+          <IconButton
+            variant="ghost"
+            size="xs"
+            aria-label="Flat"
+            title="Flat"
+            height={6}
+            icon={
+              expandMode === "collapsed" ? (
+                <BsArrowsExpand size={15} />
+              ) : (
+                <BsArrowsCollapse size={15} />
+              )
+            }
+            onClick={(e) => {
+              setExpandMode(
+                expandMode === "expanded" ? "collapsed" : "expanded"
+              );
+              e.stopPropagation();
+            }}
+          />
+          {isEffect && (
+            <HStack position="absolute" right={0}>
+              {effectIndex < lastEffectIndex && (
+                <IconButton
+                  variant="link"
+                  aria-label="Move down"
+                  title="Move down"
+                  height={6}
+                  _hover={{ color: "blue.500" }}
+                  icon={<RxCaretDown size={28} />}
+                  onClick={action(() =>
+                    parentBlock.reorderEffectBlock(block, 1)
+                  )}
+                />
+              )}
+              {effectIndex > 0 && (
+                <IconButton
+                  variant="link"
+                  aria-label="Move up"
+                  title="Move up"
+                  height={6}
+                  _hover={{ color: "blue.500" }}
+                  icon={<RxCaretUp size={28} />}
+                  onClick={action(() =>
+                    parentBlock.reorderEffectBlock(block, -1)
+                  )}
+                />
+              )}
               <IconButton
                 variant="link"
-                aria-label="Move down"
-                title="Move down"
+                aria-label="Delete effect"
+                title="Delete effect"
                 height={6}
-                _hover={{ color: "blue.500" }}
-                icon={<RxCaretDown size={28} />}
-                onClick={action(() => parentBlock.reorderEffectBlock(block, 1))}
+                _hover={{ color: "red.500" }}
+                icon={<FaTrashAlt size={12} />}
+                onClick={action(() => parentBlock.removeEffectBlock(block))}
               />
-            )}
-            {effectIndex > 0 && (
-              <IconButton
-                variant="link"
-                aria-label="Move up"
-                title="Move up"
-                height={6}
-                _hover={{ color: "blue.500" }}
-                icon={<RxCaretUp size={28} />}
-                onClick={action(() =>
-                  parentBlock.reorderEffectBlock(block, -1)
-                )}
-              />
-            )}
-            <IconButton
-              variant="link"
-              aria-label="Delete effect"
-              title="Delete effect"
-              height={6}
-              _hover={{ color: "red.500" }}
-              icon={<FaTrashAlt size={12} />}
-              onClick={action(() => parentBlock.removeEffectBlock(block))}
-            />
-          </HStack>
-        )}
+            </HStack>
+          )}
+        </HeaderRepeat>
       </HStack>
       <ParametersList expandMode={expandMode} block={block} />
     </>

--- a/src/components/TimelineBlockStack.tsx
+++ b/src/components/TimelineBlockStack.tsx
@@ -30,10 +30,18 @@ export const TimelineBlockStack = observer(function TimelineBlockStack({
   const dragNodeRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     if (!dragNodeRef.current) return;
-    new ResizeObserver(() => patternBlock.layer?.recomputeHeight()).observe(
-      dragNodeRef.current
-    );
-  }, [dragNodeRef, patternBlock.layer]);
+
+    // Anytime the TimelineBlockStack is resized,
+    new ResizeObserver(() => {
+      // recompute the height of the layer
+      patternBlock.layer?.recomputeHeight();
+
+      // recompute the number of header repetitions
+      patternBlock.recomputeHeaderRepetitions(
+        dragNodeRef.current?.clientWidth ?? 0
+      );
+    }).observe(dragNodeRef.current);
+  }, [dragNodeRef, patternBlock.layer, patternBlock]);
 
   const lastMouseDown = useRef(0);
 

--- a/src/components/TimelineLayerHeader.tsx
+++ b/src/components/TimelineLayerHeader.tsx
@@ -79,13 +79,7 @@ export const TimelineLayerHeader = observer(function TimelineLayerHeader({
             />
           )}
       </VStack>
-      <HStack
-        // position="absolute"
-        // bottom={0}
-        // height="40px"
-        justify="center"
-        spacing={0}
-      >
+      <HStack justify="center" spacing={0}>
         <Button
           mb={2}
           color={layer.showingOpacityControls ? "white" : "black"}

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -226,7 +226,8 @@ export class Block<T extends ExtraParams = {}> {
   };
 
   recomputeHeaderRepetitions = (width: number) => {
-    this.headerRepetitions = Math.ceil(width / 1200);
+    // average screen width is 1280px, so repeat header and additional time for each multiple of this
+    this.headerRepetitions = Math.floor(width / 1280) + 1;
 
     this.effectBlocks.forEach((effect) =>
       effect.recomputeHeaderRepetitions(width)

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -29,6 +29,8 @@ export class Block<T extends ExtraParams = {}> {
   startTime: number = 0; // global time that block starts playing at in seconds
   duration: number = 5; // duration that block plays for in seconds
 
+  headerRepetitions: number = 1; // number of times to repeat the headers in this block
+
   private _layer: Layer | null = null; // the layer that this block is in
 
   get layer() {
@@ -221,6 +223,14 @@ export class Block<T extends ExtraParams = {}> {
 
     // create a new array so that mobx can detect the change
     this.parameterVariations[uniformName as keyof T] = [...variations];
+  };
+
+  recomputeHeaderRepetitions = (width: number) => {
+    this.headerRepetitions = Math.ceil(width / 1200);
+
+    this.effectBlocks.forEach((effect) =>
+      effect.recomputeHeaderRepetitions(width)
+    );
   };
 
   reorderEffectBlock = (block: Block, delta: number) => {


### PR DESCRIPTION
![image](https://github.com/SotSF/conjurer/assets/12655228/16130aa4-f3e0-4fe4-9ab9-a148483ef637)

It is commonly the case that the block is so wide that you couldn't readily tell which pattern, effect, or parameter that you were editing because the header was centered and out of view. This change repeats headers every 1280px.