### PR TITLE
Audio reactive variations

### DIFF
--- a/src/components/NewVariationButtons.tsx
+++ b/src/components/NewVariationButtons.tsx
@@ -8,6 +8,7 @@ import {
   TbEaseInOutControlPoints,
 } from "react-icons/tb";
 import { MdTrendingFlat, MdColorLens } from "react-icons/md";
+import { PiWaveform } from "react-icons/pi";
 import { Block } from "@/src/types/Block";
 import { action } from "mobx";
 import { FlatVariation } from "@/src/types/Variations/FlatVariation";
@@ -24,6 +25,7 @@ import { useStore } from "@/src/types/StoreContext";
 import { EasingVariation } from "@/src/types/Variations/EasingVariation";
 import { Palette, isPalette } from "@/src/types/Palette";
 import { PaletteVariation } from "@/src/types/Variations/PaletteVariation";
+import { AudioVariation } from "@/src/types/Variations/AudioVariation";
 
 type NewVariationButtonsProps = {
   uniformName: string;
@@ -231,6 +233,20 @@ export const NewVariationButtons = memo(function NewVariationButtons({
             block,
             uniformName,
             new EasingVariation(DEFAULT_VARIATION_DURATION, "easeInSine", 0, 1)
+          );
+        })}
+      />
+      <IconButton
+        size="xs"
+        aria-label="Audio"
+        title="Audio"
+        height={6}
+        icon={<PiWaveform size={17} />}
+        onClick={action(() => {
+          store.addVariation(
+            block,
+            uniformName,
+            new AudioVariation(DEFAULT_VARIATION_DURATION, 1, 0)
           );
         })}
       />

--- a/src/components/NewVariationButtons.tsx
+++ b/src/components/NewVariationButtons.tsx
@@ -246,7 +246,7 @@ export const NewVariationButtons = memo(function NewVariationButtons({
           store.addVariation(
             block,
             uniformName,
-            new AudioVariation(DEFAULT_VARIATION_DURATION, 1, 0)
+            new AudioVariation(DEFAULT_VARIATION_DURATION, 1, 0, store)
           );
         })}
       />

--- a/src/components/PatternPlayground/PatternPlayground.tsx
+++ b/src/components/PatternPlayground/PatternPlayground.tsx
@@ -19,8 +19,8 @@ export const PatternPlayground = observer(function PatternPlayground() {
 
   // TODO: in dire need of refactoring
   const patternBlocks = useMemo(
-    () => playgroundPatterns.map((pattern) => new Block(pattern), []),
-    []
+    () => playgroundPatterns.map((pattern) => new Block(store, pattern), []),
+    [store]
   );
   const [selectedPatternIndex, setSelectedPatternIndex] = useState(
     uiStore.lastPatternIndexSelected
@@ -29,8 +29,8 @@ export const PatternPlayground = observer(function PatternPlayground() {
     patternBlocks[selectedPatternIndex] ?? patternBlocks[0];
 
   const effectBlocks = useMemo(
-    () => playgroundEffects.map((effect) => new Block(effect)),
-    []
+    () => playgroundEffects.map((effect) => new Block(store, effect)),
+    [store]
   );
 
   const [selectedEffectIndices, setSelectedEffectIndices] = useState<number[]>(

--- a/src/components/VariationControls/AudioVariationControls.tsx
+++ b/src/components/VariationControls/AudioVariationControls.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { Block } from "@/src/types/Block";
+import { ScalarInput } from "@/src/components/ScalarInput";
+import { AudioVariation } from "@/src/types/Variations/AudioVariation";
+
+type AudioVariationControlsProps = {
+  uniformName: string;
+  variation: AudioVariation;
+  block: Block;
+};
+
+export function AudioVariationControls({
+  uniformName,
+  variation,
+  block,
+}: AudioVariationControlsProps) {
+  const [factor, setFactor] = useState(variation.factor.toString());
+  const [offset, setOffset] = useState(variation.offset.toString());
+
+  return (
+    <>
+      <ScalarInput
+        name="Factor"
+        onChange={(valueString, valueNumber) => {
+          variation.factor = valueNumber;
+          setFactor(valueString);
+          block.triggerVariationReactions(uniformName);
+        }}
+        value={factor}
+      />
+      <ScalarInput
+        name="Offset"
+        onChange={(valueString, valueNumber) => {
+          variation.offset = valueNumber;
+          setOffset(valueString);
+          block.triggerVariationReactions(uniformName);
+        }}
+        value={offset}
+      />
+    </>
+  );
+}

--- a/src/components/VariationControls/VariationControls.tsx
+++ b/src/components/VariationControls/VariationControls.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   HStack,
   Icon,
-  Input,
   Link,
   Radio,
   RadioGroup,
@@ -38,10 +37,9 @@ import {
 } from "@/src/types/Variations/EasingVariation";
 import { easings } from "@/src/utils/easings";
 import { PaletteVariation } from "@/src/types/Variations/PaletteVariation";
-import { isPalette } from "@/src/types/Palette";
-import { Vector3 } from "three";
-import { PaletteEditorModal } from "@/src/components/PalletteEditor/PaletteEditorModal";
 import { PaletteVariationControls } from "@/src/components/VariationControls/PaletteVariationControls";
+import { AudioVariation } from "@/src/types/Variations/AudioVariation";
+import { AudioVariationControls } from "@/src/components/VariationControls/AudioVariationControls";
 
 type VariationControlsProps = {
   uniformName: string;
@@ -70,6 +68,8 @@ export const VariationControls = function VariationControls({
       <SplineVariationControls variation={variation} {...controlsProps} />
     ) : variation instanceof EasingVariation ? (
       <EasingVariationControls variation={variation} {...controlsProps} />
+    ) : variation instanceof AudioVariation ? (
+      <AudioVariationControls variation={variation} {...controlsProps} />
     ) : variation instanceof LinearVariation4 ? (
       <LinearVariation4Controls variation={variation} {...controlsProps} />
     ) : variation instanceof PaletteVariation ? (

--- a/src/components/VariationGraph/ScalarVariationGraph.tsx
+++ b/src/components/VariationGraph/ScalarVariationGraph.tsx
@@ -38,7 +38,10 @@ export const ScalarVariationGraph = function ScalarVariationGraph({
       />
     );
 
-  const data = variation.computeSampledData(variation.duration);
+  const data = variation.computeSampledData(
+    variation.duration,
+    block.startTime
+  );
 
   return (
     <Box

--- a/src/components/Wavesurfer/WavesurferWaveform.tsx
+++ b/src/components/Wavesurfer/WavesurferWaveform.tsx
@@ -104,14 +104,6 @@ export const WavesurferWaveform = observer(function WavesurferWaveform() {
       const wavesurferRef = (audioStore.wavesurfer =
         WaveSurfer.create(options));
 
-      // Load selected audio file
-      if (audioStore.selectedAudioFile) {
-        await wavesurferRef.load(audioStore.getSelectedAudioFileUrl());
-        wavesurferRef?.zoom(uiStore.pixelsPerSecond);
-        audioStore.audioBuffer = wavesurferRef.getDecodedData();
-        ready.current = true;
-      }
-
       wavesurferRef.on("interaction", (newTime: number) => {
         if (!wavesurferRef) return;
         timer.setTime(Math.max(0, newTime));
@@ -156,7 +148,10 @@ export const WavesurferWaveform = observer(function WavesurferWaveform() {
         await audioStore.wavesurfer.load(audioStore.getSelectedAudioFileUrl());
         audioStore.wavesurfer.zoom(uiStore.pixelsPerSecond);
         audioStore.wavesurfer.seekTo(0);
-        audioStore.audioBuffer = audioStore.wavesurfer.getDecodedData();
+
+        const audioBuffer = audioStore.wavesurfer.getDecodedData();
+        if (audioBuffer) audioStore.computePeaks(audioBuffer);
+
         ready.current = true;
         setLoading(false);
       }

--- a/src/types/AudioStore.ts
+++ b/src/types/AudioStore.ts
@@ -56,7 +56,17 @@ export class AudioStore {
     const totalDesiredSamples = Math.floor(
       PEAK_DATA_SAMPLE_RATE * audioBuffer.duration
     );
-    this.peaks = filterData(audioBuffer, totalDesiredSamples)[0]; // first channel only for now
+    const channelData = filterData(audioBuffer, totalDesiredSamples, true);
+    const numberOfChannels = channelData.length;
+
+    this.peaks = [];
+    for (let j = 0; j < channelData[0].length; j++) {
+      let frameTotal = 0;
+      for (let i = 0; i < numberOfChannels; i++) {
+        frameTotal += channelData[i][j];
+      }
+      this.peaks.push(frameTotal / numberOfChannels);
+    }
   };
 
   getPeakAtTime = (time: number) => {

--- a/src/types/AudioStore.ts
+++ b/src/types/AudioStore.ts
@@ -46,6 +46,8 @@ export class AudioStore {
       wavesurfer: false,
       timeline: false,
       regions: false,
+      peaks: false,
+      getPeakAtTime: false,
     });
     this.timer.addTickListener(this.onTick);
   }
@@ -55,6 +57,12 @@ export class AudioStore {
       PEAK_DATA_SAMPLE_RATE * audioBuffer.duration
     );
     this.peaks = filterData(audioBuffer, totalDesiredSamples)[0]; // first channel only for now
+  };
+
+  getPeakAtTime = (time: number) => {
+    if (!this.peaks.length) return 0;
+    const index = Math.floor(time * PEAK_DATA_SAMPLE_RATE);
+    return this.peaks[index];
   };
 
   toggleAudioMuted = () => {

--- a/src/types/AudioStore.ts
+++ b/src/types/AudioStore.ts
@@ -12,8 +12,11 @@ import type WaveSurfer from "wavesurfer.js";
 import type TimelinePlugin from "wavesurfer.js/dist/plugins/timeline";
 import type RegionsPlugin from "wavesurfer.js/dist/plugins/regions";
 import type { RegionParams } from "wavesurfer.js/dist/plugins/regions";
+import { filterData } from "@/src/types/audioPeaks";
 
 export const loopRegionColor = "rgba(237, 137, 54, 0.4)";
+
+export const PEAK_DATA_SAMPLE_RATE = 30;
 
 // Define a new RootStore interface here so that we avoid circular dependencies
 interface RootStore {
@@ -30,7 +33,7 @@ export class AudioStore {
   timeline: TimelinePlugin | null = null;
   regions: RegionsPlugin | null = null;
 
-  audioBuffer: AudioBuffer | null = null; // currently unused
+  peaks: number[] = [];
 
   markingAudio = false;
 
@@ -40,13 +43,19 @@ export class AudioStore {
   constructor(readonly rootStore: RootStore, readonly timer: Timer) {
     makeAutoObservable(this, {
       getSelectedAudioFileUrl: false,
-      audioBuffer: false,
       wavesurfer: false,
       timeline: false,
       regions: false,
     });
     this.timer.addTickListener(this.onTick);
   }
+
+  computePeaks = (audioBuffer: AudioBuffer) => {
+    const totalDesiredSamples = Math.floor(
+      PEAK_DATA_SAMPLE_RATE * audioBuffer.duration
+    );
+    this.peaks = filterData(audioBuffer, totalDesiredSamples)[0]; // first channel only for now
+  };
 
   toggleAudioMuted = () => {
     this.audioMuted = !this.audioMuted;

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -378,7 +378,9 @@ export class Block<T extends ExtraParams = {}> {
     for (const parameter of Object.keys(data.parameterVariations)) {
       block.parameterVariations[parameter] = data.parameterVariations[
         parameter
-      ]?.map((variationData: any) => deserializeVariation(variationData));
+      ]?.map((variationData: any) =>
+        deserializeVariation(store, variationData)
+      );
     }
 
     block.effectBlocks = data.effectBlocks.map((effectBlockData: any) =>

--- a/src/types/Store.ts
+++ b/src/types/Store.ts
@@ -353,7 +353,7 @@ export class Store {
     const uniformNameToPasteTo = selectedVariations[0].uniformName;
 
     const variationsToPaste = blocksOrVariationsData.map((v) =>
-      deserializeVariation(v)
+      deserializeVariation(this, v)
     );
 
     this.selectedBlocksOrVariations = new Set();

--- a/src/types/Store.ts
+++ b/src/types/Store.ts
@@ -324,7 +324,7 @@ export class Store {
       if (!layerToPasteInto) return;
 
       const blocksToPaste = blocksOrVariationsData.map((b: any) =>
-        Block.deserialize(b)
+        Block.deserialize(this, b)
       );
       this.selectedBlocksOrVariations = new Set();
       for (const blockToPaste of blocksToPaste) {
@@ -416,7 +416,7 @@ export class Store {
   deserialize = (data: any) => {
     this.audioStore.deserialize(data.audioStore);
     this.uiStore.deserialize(data.uiStore);
-    this.layers = data.layers.map((l: any) => Layer.deserialize(l, this.timer));
+    this.layers = data.layers.map((l: any) => Layer.deserialize(this, l));
     this.selectedLayer = this.layers[0];
   };
 }

--- a/src/types/Variations/AudioVariation.ts
+++ b/src/types/Variations/AudioVariation.ts
@@ -24,7 +24,7 @@ export class AudioVariation extends Variation<number> {
   computeDomain = () => [0, 1] as [number, number];
 
   computeSampledData = (duration: number) => {
-    const totalSamples = Math.ceil(duration * 10);
+    const totalSamples = Math.ceil(duration * 30);
 
     const data = [];
     for (let i = 0; i < totalSamples; i++) {

--- a/src/types/Variations/AudioVariation.ts
+++ b/src/types/Variations/AudioVariation.ts
@@ -1,21 +1,24 @@
-import { Variation } from "@/src/types/Variations/Variation";
+import { Variation, RootStore } from "@/src/types/Variations/Variation";
 
 export class AudioVariation extends Variation<number> {
   displayName = "Audio";
   factor: number;
   offset: number;
 
-  constructor(duration: number, factor: number, offset: number) {
+  constructor(
+    duration: number,
+    factor: number,
+    offset: number,
+    readonly store: RootStore
+  ) {
     super("audio", duration);
 
     this.factor = factor;
     this.offset = offset;
   }
 
-  valueAtTime = (time: number) => {
-    // TODO:
-    return 1;
-  };
+  valueAtTime = (time: number) =>
+    this.factor * this.store.audioStore.getPeakAtTime(time) + this.offset;
 
   // TODO:
   computeDomain = () => [0, 1] as [number, number];
@@ -32,7 +35,8 @@ export class AudioVariation extends Variation<number> {
     return data;
   };
 
-  clone = () => new AudioVariation(this.duration, this.factor, this.offset);
+  clone = () =>
+    new AudioVariation(this.duration, this.factor, this.offset, this.store);
 
   serialize = () => ({
     type: this.type,
@@ -41,6 +45,6 @@ export class AudioVariation extends Variation<number> {
     offset: this.offset,
   });
 
-  static deserialize = (data: any) =>
-    new AudioVariation(data.duration, data.factor, data.offset);
+  static deserialize = (store: RootStore, data: any) =>
+    new AudioVariation(data.duration, data.factor, data.offset, store);
 }

--- a/src/types/Variations/AudioVariation.ts
+++ b/src/types/Variations/AudioVariation.ts
@@ -17,19 +17,22 @@ export class AudioVariation extends Variation<number> {
     this.offset = offset;
   }
 
-  valueAtTime = (time: number) =>
-    this.factor * this.store.audioStore.getPeakAtTime(time) + this.offset;
+  valueAtTime = (time: number, globalTime: number) =>
+    this.factor * this.store.audioStore.getPeakAtTime(globalTime) + this.offset;
 
   // TODO:
   computeDomain = () => [0, 1] as [number, number];
 
-  computeSampledData = (duration: number) => {
+  computeSampledData = (duration: number, globalStartTime = 0) => {
     const totalSamples = Math.ceil(duration * 30);
 
     const data = [];
     for (let i = 0; i < totalSamples; i++) {
       data.push({
-        value: this.valueAtTime(duration * (i / (totalSamples - 1))),
+        value: this.valueAtTime(
+          0,
+          globalStartTime + duration * (i / (totalSamples - 1))
+        ),
       });
     }
     return data;

--- a/src/types/Variations/AudioVariation.ts
+++ b/src/types/Variations/AudioVariation.ts
@@ -1,0 +1,46 @@
+import { Variation } from "@/src/types/Variations/Variation";
+
+export class AudioVariation extends Variation<number> {
+  displayName = "Audio";
+  factor: number;
+  offset: number;
+
+  constructor(duration: number, factor: number, offset: number) {
+    super("audio", duration);
+
+    this.factor = factor;
+    this.offset = offset;
+  }
+
+  valueAtTime = (time: number) => {
+    // TODO:
+    return 1;
+  };
+
+  // TODO:
+  computeDomain = () => [0, 1] as [number, number];
+
+  computeSampledData = (duration: number) => {
+    const totalSamples = Math.ceil(duration * 10);
+
+    const data = [];
+    for (let i = 0; i < totalSamples; i++) {
+      data.push({
+        value: this.valueAtTime(duration * (i / (totalSamples - 1))),
+      });
+    }
+    return data;
+  };
+
+  clone = () => new AudioVariation(this.duration, this.factor, this.offset);
+
+  serialize = () => ({
+    type: this.type,
+    duration: this.duration,
+    factor: this.factor,
+    offset: this.offset,
+  });
+
+  static deserialize = (data: any) =>
+    new AudioVariation(data.duration, data.factor, data.offset);
+}

--- a/src/types/Variations/EasingVariation.ts
+++ b/src/types/Variations/EasingVariation.ts
@@ -1,4 +1,4 @@
-import { Variation } from "@/src/types/Variations/Variation";
+import { RootStore, Variation } from "@/src/types/Variations/Variation";
 import { easings } from "@/src/utils/easings";
 
 export type EasingVariationType =
@@ -85,6 +85,6 @@ export class EasingVariation extends Variation<number> {
     to: this.to,
   });
 
-  static deserialize = (data: any) =>
+  static deserialize = (store: RootStore, data: any) =>
     new EasingVariation(data.duration, data.easingType, data.from, data.to);
 }

--- a/src/types/Variations/FlatVariation.ts
+++ b/src/types/Variations/FlatVariation.ts
@@ -1,4 +1,4 @@
-import { Variation } from "@/src/types/Variations/Variation";
+import { RootStore, Variation } from "@/src/types/Variations/Variation";
 
 export class FlatVariation extends Variation<number> {
   displayName = "Flat";
@@ -33,6 +33,6 @@ export class FlatVariation extends Variation<number> {
     value: this.value,
   });
 
-  static deserialize = (data: any) =>
+  static deserialize = (store: RootStore, data: any) =>
     new FlatVariation(data.duration, data.value);
 }

--- a/src/types/Variations/LinearVariation.ts
+++ b/src/types/Variations/LinearVariation.ts
@@ -1,4 +1,4 @@
-import { Variation } from "@/src/types/Variations/Variation";
+import { RootStore, Variation } from "@/src/types/Variations/Variation";
 import { lerp } from "three/src/math/MathUtils";
 
 export class LinearVariation extends Variation<number> {
@@ -36,6 +36,6 @@ export class LinearVariation extends Variation<number> {
     to: this.to,
   });
 
-  static deserialize = (data: any) =>
+  static deserialize = (store: RootStore, data: any) =>
     new LinearVariation(data.duration, data.from, data.to);
 }

--- a/src/types/Variations/LinearVariation4.ts
+++ b/src/types/Variations/LinearVariation4.ts
@@ -1,4 +1,4 @@
-import { Variation } from "@/src/types/Variations/Variation";
+import { RootStore, Variation } from "@/src/types/Variations/Variation";
 import { Vector4 } from "three";
 
 export class LinearVariation4 extends Variation<Vector4> {
@@ -40,7 +40,7 @@ export class LinearVariation4 extends Variation<Vector4> {
     to: this.to.toArray(),
   });
 
-  static deserialize = (data: any) =>
+  static deserialize = (store: RootStore, data: any) =>
     new LinearVariation4(
       data.duration,
       new Vector4(...data.from),

--- a/src/types/Variations/PaletteVariation.ts
+++ b/src/types/Variations/PaletteVariation.ts
@@ -1,5 +1,5 @@
 import { Palette } from "@/src/types/Palette";
-import { Variation } from "@/src/types/Variations/Variation";
+import { RootStore, Variation } from "@/src/types/Variations/Variation";
 import { Vector3 } from "three";
 
 export class PaletteVariation extends Variation<Palette> {
@@ -31,7 +31,7 @@ export class PaletteVariation extends Variation<Palette> {
     palette: this.palette.serialize(),
   });
 
-  static deserialize = (data: any) =>
+  static deserialize = (store: RootStore, data: any) =>
     new PaletteVariation(
       data.duration,
       new Palette(

--- a/src/types/Variations/PeriodicVariation.ts
+++ b/src/types/Variations/PeriodicVariation.ts
@@ -1,4 +1,4 @@
-import { Variation } from "@/src/types/Variations/Variation";
+import { RootStore, Variation } from "@/src/types/Variations/Variation";
 
 export type PeriodicVariationType = "sine" | "square" | "triangle";
 
@@ -118,7 +118,7 @@ export class PeriodicVariation extends Variation<number> {
     offset: this.offset,
   });
 
-  static deserialize = (data: any) =>
+  static deserialize = (store: RootStore, data: any) =>
     new PeriodicVariation(
       data.duration,
       data.periodicType,

--- a/src/types/Variations/SplineVariation.ts
+++ b/src/types/Variations/SplineVariation.ts
@@ -1,4 +1,4 @@
-import { Variation } from "@/src/types/Variations/Variation";
+import { RootStore, Variation } from "@/src/types/Variations/Variation";
 import { CubicSpline } from "splines";
 
 export const DEFAULT_SPLINE_POINTS = [
@@ -86,7 +86,7 @@ export class SplineVariation extends Variation<number> {
     domainMax: this.domainMax,
   });
 
-  static deserialize = (data: any) =>
+  static deserialize = (store: RootStore, data: any) =>
     new SplineVariation(
       data.duration,
       data.points,

--- a/src/types/Variations/Variation.ts
+++ b/src/types/Variations/Variation.ts
@@ -28,7 +28,10 @@ export abstract class Variation<T extends ParamType = ParamType> {
 
   abstract valueAtTime: (time: number, globalTime: number) => T;
   abstract computeDomain: () => [number, number];
-  abstract computeSampledData: (duration: number) => { value: number }[];
+  abstract computeSampledData: (
+    duration: number,
+    globalStartTime?: number
+  ) => { value: number }[];
   abstract clone: () => Variation<T>;
   abstract serialize: () => any;
   static deserialize: (store: RootStore, data: any) => Variation;

--- a/src/types/Variations/Variation.ts
+++ b/src/types/Variations/Variation.ts
@@ -1,5 +1,9 @@
 import { ParamType } from "@/src/types/PatternParams";
 
+export type RootStore = {
+  audioStore: { getPeakAtTime: (time: number) => number };
+};
+
 type VariationType =
   | "flat"
   | "linear"
@@ -27,5 +31,5 @@ export abstract class Variation<T extends ParamType = ParamType> {
   abstract computeSampledData: (duration: number) => { value: number }[];
   abstract clone: () => Variation<T>;
   abstract serialize: () => any;
-  static deserialize: (data: any) => Variation;
+  static deserialize: (store: RootStore, data: any) => Variation;
 }

--- a/src/types/Variations/Variation.ts
+++ b/src/types/Variations/Variation.ts
@@ -22,7 +22,7 @@ export abstract class Variation<T extends ParamType = ParamType> {
     this.duration = duration;
   }
 
-  abstract valueAtTime: (time: number) => T;
+  abstract valueAtTime: (time: number, globalTime: number) => T;
   abstract computeDomain: () => [number, number];
   abstract computeSampledData: (duration: number) => { value: number }[];
   abstract clone: () => Variation<T>;

--- a/src/types/Variations/Variation.ts
+++ b/src/types/Variations/Variation.ts
@@ -6,6 +6,7 @@ type VariationType =
   | "periodic"
   | "spline"
   | "easing"
+  | "audio"
   | "linear4"
   | "palette";
 

--- a/src/types/Variations/variations.ts
+++ b/src/types/Variations/variations.ts
@@ -6,26 +6,29 @@ import { PaletteVariation } from "@/src/types/Variations/PaletteVariation";
 import { PeriodicVariation } from "@/src/types/Variations/PeriodicVariation";
 import { SplineVariation } from "@/src/types/Variations/SplineVariation";
 import { AudioVariation } from "@/src/types/Variations/AudioVariation";
-import { Variation } from "@/src/types/Variations/Variation";
+import { RootStore, Variation } from "@/src/types/Variations/Variation";
 
-export const deserializeVariation = (data: any): Variation => {
+export const deserializeVariation = (
+  store: RootStore,
+  data: any
+): Variation => {
   switch (data.type) {
     case "flat":
-      return FlatVariation.deserialize(data);
+      return FlatVariation.deserialize(store, data);
     case "linear":
-      return LinearVariation.deserialize(data);
+      return LinearVariation.deserialize(store, data);
     case "periodic":
-      return PeriodicVariation.deserialize(data);
+      return PeriodicVariation.deserialize(store, data);
     case "spline":
-      return SplineVariation.deserialize(data);
+      return SplineVariation.deserialize(store, data);
     case "easing":
-      return EasingVariation.deserialize(data);
+      return EasingVariation.deserialize(store, data);
     case "audio":
-      return AudioVariation.deserialize(data);
+      return AudioVariation.deserialize(store, data);
     case "linear4":
-      return LinearVariation4.deserialize(data);
+      return LinearVariation4.deserialize(store, data);
     case "palette":
-      return PaletteVariation.deserialize(data);
+      return PaletteVariation.deserialize(store, data);
     default:
       throw new Error(
         `Need to implement deserialization for variation type: ${data.type}`

--- a/src/types/Variations/variations.ts
+++ b/src/types/Variations/variations.ts
@@ -5,6 +5,7 @@ import { LinearVariation4 } from "@/src/types/Variations/LinearVariation4";
 import { PaletteVariation } from "@/src/types/Variations/PaletteVariation";
 import { PeriodicVariation } from "@/src/types/Variations/PeriodicVariation";
 import { SplineVariation } from "@/src/types/Variations/SplineVariation";
+import { AudioVariation } from "@/src/types/Variations/AudioVariation";
 import { Variation } from "@/src/types/Variations/Variation";
 
 export const deserializeVariation = (data: any): Variation => {
@@ -19,6 +20,8 @@ export const deserializeVariation = (data: any): Variation => {
       return SplineVariation.deserialize(data);
     case "easing":
       return EasingVariation.deserialize(data);
+    case "audio":
+      return AudioVariation.deserialize(data);
     case "linear4":
       return LinearVariation4.deserialize(data);
     case "palette":

--- a/src/types/audioPeaks.ts
+++ b/src/types/audioPeaks.ts
@@ -1,0 +1,108 @@
+// Source: https://github.com/califken/node-audio-peaks/blob/main/index.js
+// Author: https://github.com/califken
+// License: GPL-3.0
+// This is a modified version of the original source code.
+
+/**
+ * Filters the AudioBuffer
+ * @param {AudioBuffer} audioBuffer the AudioBuffer from drawAudio()
+ * @param {Number} samples the number of samples to generate data for
+ * @param {Boolean} allchannels by default, generatePeaks only returns the first channel.  set this to true to return an array for each channel
+ * @returns {Array} an array of floating point numbers
+ */
+export const filterData = (
+  audioBuffer: AudioBuffer,
+  samples: number,
+  allchannels = false
+) => {
+  const channels = allchannels ? audioBuffer.numberOfChannels : 1;
+  let filteredDataChannels = [];
+  let currentchannel = 0;
+  for (currentchannel = 0; currentchannel < channels; currentchannel++) {
+    const rawData = audioBuffer.getChannelData(currentchannel); // We only need to work with one channel of data
+    const blockSize = Math.floor(rawData.length / samples); // the number of samples in each subdivision
+    const filteredData = [];
+    for (let i = 0; i < samples; i++) {
+      let blockStart = blockSize * i; // the location of the first sample in the block
+      let sum = 0;
+      for (let j = 0; j < blockSize; j++) {
+        sum = sum + Math.abs(rawData[blockStart + j]); // find the sum of all the samples in the block
+      }
+      filteredData.push(sum / blockSize); // divide the sum by the block size to get the average
+    }
+    filteredDataChannels[currentchannel] = filteredData;
+  }
+  return filteredDataChannels;
+};
+
+/**
+ * Normalizes the audio data
+ * @param {Array} filteredData the data from filterData()
+ * @returns {Array} an normalized array of floating point numbers
+ */
+// const normalizeData = (filteredDataChannels) => {
+//   let multipliers = [];
+//   let normalized = [];
+//   filteredDataChannels.map((c, i) => {
+//     let multiplier = Math.pow(Math.max(...c), -1);
+//     normalized[i] = c.map((n) => n * multiplier);
+//   });
+//   return normalized;
+// };
+
+/**
+ * Generate audio peaks from a local filepath
+ * @param {string} audiofile Local filepath
+ * @param {samples} samples The number of "peaks" to return
+ * @returns {Array} a normalized array of peaks from the first channel of audio
+ */
+// function audioPeaksFromFile(audiofile, samples) {
+//   return of(audiofile).pipe(
+//     switchMap((filepath) => {
+//       return from(promises.readFile(filepath));
+//     }),
+//     map((filedata) => new _Blob([filedata.buffer])),
+//     switchMap((blob) => from(blob.arrayBuffer())),
+//     switchMap((arrayBuffer) => from(decode(arrayBuffer))),
+//     map((audioBuffer) =>
+//       filterData(audioBuffer, samples ? samples : 70, false)
+//     ),
+//     map((filteredData) => normalizeData(filteredData, false)),
+//     map((normalizedData) => normalizedData[0])
+//   );
+// }
+
+/**
+ * Generate audio peaks from remote file URL
+ * @param {string} audiofileurl Remote file URL
+ * @param {samples} samples The number of "peaks" to return
+ * @returns {Array} a normalized array of peaks from the first channel of audio
+ */
+// function audioPeaksFromURL(audiofileurl, samples) {
+//   return of(audiofileurl).pipe(
+//     switchMap((audiofileurl) => {
+//       return from(fetch(audiofileurl));
+//     }),
+//     switchMap((file) => from(file.arrayBuffer())),
+//     switchMap((arrayBuffer) => from(decode(arrayBuffer))),
+//     map((audioBuffer) =>
+//       filterData(audioBuffer, samples ? samples : 70, false)
+//     ),
+//     map((filteredData) => normalizeData(filteredData, false)),
+//     map((normalizedData) => normalizedData[0])
+//   );
+// }
+
+/**
+ * Generate audio peaks from local filepath or remote file URL
+ * @param {string} audio Local filepath or remote file URL
+ * @param {samples} samples The number of "peaks" to return
+ * @returns {Array} a normalized array of peaks from the first channel of audio
+ */
+// export function getAudioPeaks(audio, samples) {
+//   if (audio.substr(0, 4) == "http") {
+//     return audioPeaksFromURL(audio, samples);
+//   } else {
+//     return audioPeaksFromFile(audio, samples);
+//   }
+// }


### PR DESCRIPTION
![image](https://github.com/SotSF/conjurer/assets/12655228/3929119c-0ceb-4dd5-a90d-d377997805a8)

Audio data is now available to variations! We can do some more sophisticated things with it, but with this change we create a simple audio variation which can be used to map a parameter to that audio data. You can apply a factor and an offset to the audio "peak".