### PR TITLE
Improve conjurer common coordinate systems

### DIFF
--- a/src/effects/shaders/shaper.frag
+++ b/src/effects/shaders/shaper.frag
@@ -54,7 +54,7 @@ void main(void) {
     // vec2 st = gl_FragCoord.xy / u_resolution.xy;
     vec2 st = v_uv;
 
-    st = canopyToCartesianProjection(st);
+    st = canopyToHalfCartesianProjection(st);
 
     vec3 color = vec3(0.0);
 

--- a/src/effects/shaders/tiler.frag
+++ b/src/effects/shaders/tiler.frag
@@ -30,7 +30,7 @@ void main(void) {
     vec2 st = v_uv;
 
     // canopy to centered cartesian space
-    st = canopyToCartesianProjection(st);
+    st = canopyToHalfCartesianProjection(st);
 
     // rotate the global space
     st = rotate2DCentered(st, PI * u_rotation_rate * u_time + PI * u_rotation);

--- a/src/patterns/shaders/convergence.frag
+++ b/src/patterns/shaders/convergence.frag
@@ -47,7 +47,7 @@ float wave(vec2 st, float edge, float size, float intensityFactor) {
 void main() {
     vec2 st = v_uv;
 
-    vec2 cartesian = canopyToCartesianProjection(st) + 0.5;
+    vec2 cartesian = canopyToHalfCartesianProjection(st) + 0.5;
 
     float time = u_time * u_time_factor + u_time_offset;
 


### PR DESCRIPTION
A follow up improvement to https://github.com/SotSF/conjurer/pull/175. What I historically referred to as cartesian is a little atypical since it goes from -0.5 to 0.5, when most of the time with shader programming it goes from -1 to 1. We'll call the first case "half cartesian" and the second one "cartesian" from now on.