### PR TITLE
Arrangement view beat grid with snapping

### DIFF
--- a/src/components/AudioControls.tsx
+++ b/src/components/AudioControls.tsx
@@ -16,6 +16,7 @@ import { useStore } from "@/src/types/StoreContext";
 import { action } from "mobx";
 import { UploadAudioModal } from "@/src/components/UploadAudioModal";
 import { useEffect, useState } from "react";
+import { RxColumns } from "react-icons/rx";
 
 export const AudioControls = observer(function AudioControls() {
   const store = useStore();
@@ -119,8 +120,8 @@ export const AudioControls = observer(function AudioControls() {
         onClick={action(() => audioStore.toggleLoopingAudio())}
       />
       <IconButton
-        aria-label="Toggle waveform style"
-        title="Toggle waveform style"
+        aria-label="Show waveform overlay"
+        title="Show waveform overlay"
         height={6}
         icon={<BsSoundwave size={17} />}
         bgColor={uiStore.showingWaveformOverlay ? "orange.700" : undefined}
@@ -132,6 +133,21 @@ export const AudioControls = observer(function AudioControls() {
             : undefined
         }
         onClick={action(() => uiStore.toggleWaveformOverlay())}
+      />
+      <IconButton
+        aria-label="Show beat grid overlay"
+        title="Show beat grid overlay"
+        height={6}
+        icon={<RxColumns size={17} />}
+        bgColor={uiStore.showingBeatGridOverlay ? "orange.700" : undefined}
+        _hover={
+          uiStore.showingBeatGridOverlay
+            ? {
+                bgColor: "orange.600",
+              }
+            : undefined
+        }
+        onClick={action(() => uiStore.toggleBeatGridOverlay())}
       />
       <IconButton
         aria-label="Mark audio"

--- a/src/components/AudioControls.tsx
+++ b/src/components/AudioControls.tsx
@@ -17,6 +17,7 @@ import { action } from "mobx";
 import { UploadAudioModal } from "@/src/components/UploadAudioModal";
 import { useEffect, useState } from "react";
 import { RxColumns } from "react-icons/rx";
+import { PiArrowsInLineHorizontalBold } from "react-icons/pi";
 
 export const AudioControls = observer(function AudioControls() {
   const store = useStore();
@@ -148,6 +149,21 @@ export const AudioControls = observer(function AudioControls() {
             : undefined
         }
         onClick={action(() => uiStore.toggleBeatGridOverlay())}
+      />
+      <IconButton
+        aria-label="Snap to grid"
+        title="Snap to grid"
+        height={6}
+        icon={<PiArrowsInLineHorizontalBold size={17} />}
+        bgColor={uiStore.snappingToBeatGrid ? "orange.700" : undefined}
+        _hover={
+          uiStore.snappingToBeatGrid
+            ? {
+                bgColor: "orange.600",
+              }
+            : undefined
+        }
+        onClick={action(() => uiStore.toggleSnappingToBeatGrid())}
       />
       <IconButton
         aria-label="Mark audio"

--- a/src/components/BeatGrid.tsx
+++ b/src/components/BeatGrid.tsx
@@ -8,12 +8,14 @@ type BeatGridProps = {
   songTempo: number;
   songTempoOffset: number;
   songDuration: number;
+  borderColor?: string;
 };
 
 export const BeatGrid = observer(function BeatGrid({
   songTempo,
   songTempoOffset,
   songDuration,
+  borderColor,
 }: BeatGridProps) {
   const store = useStore();
   const { uiStore } = store;
@@ -25,29 +27,25 @@ export const BeatGrid = observer(function BeatGrid({
   );
 
   return (
-    <>
-      <Box
-        position="relative"
-        // width={`${canvasSize.width}px`}
-        height={"100%"}
-      >
-        {!Number.isNaN(songTempoOffset) &&
-          !Number.isNaN(songTempo) &&
-          // TODO: make this number bigger and make this more efficient
-          Array.from({ length: numberOfBeats }).map((_, index) => (
-            <Box
-              key={index}
-              position="absolute"
-              top={0}
-              left={uiStore.timeToXPixels(
-                songTempoOffset + (index * 60) / songTempo
-              )}
-              width="0px"
-              height="100%"
-              borderLeft="1px solid red"
-            />
-          ))}
-      </Box>
-    </>
+    <Box position="relative" height="100%">
+      {!Number.isNaN(songTempoOffset) &&
+        !Number.isNaN(songTempo) &&
+        Array.from({ length: numberOfBeats }).map((_, index) => (
+          <Box
+            key={index}
+            position="absolute"
+            top={0}
+            left={uiStore.timeToXPixels(
+              songTempoOffset + (index * 60) / songTempo
+            )}
+            width="0px"
+            height="100%"
+            borderLeftWidth={1}
+            borderLeftStyle="solid"
+            borderLeftColor={borderColor || "gray.500"}
+            opacity={0.5}
+          />
+        ))}
+    </Box>
   );
 });

--- a/src/components/BeatGridOverlay.tsx
+++ b/src/components/BeatGridOverlay.tsx
@@ -3,14 +3,12 @@ import { Box } from "@chakra-ui/react";
 import { useStore } from "@/src/types/StoreContext";
 import { BeatGrid } from "@/src/components/BeatGrid";
 import { useEffect, useState } from "react";
+import { runInAction } from "mobx";
 
 export const BeatGridOverlay = observer(function BeatGridOverlay() {
   const store = useStore();
   const { uiStore, audioStore } = store;
   const { showingBeatGridOverlay } = uiStore;
-
-  const [songTempo, setSongTempo] = useState(120);
-  const [songTempoOffset, setSongTempoOffset] = useState(0);
 
   useEffect(() => {
     // TODO: load this from a different source
@@ -18,9 +16,11 @@ export const BeatGridOverlay = observer(function BeatGridOverlay() {
     if (!songMetadata) return;
 
     const { songTempo, songTempoOffset } = JSON.parse(songMetadata);
-    setSongTempo(songTempo);
-    setSongTempoOffset(songTempoOffset);
-  }, []);
+    runInAction(() => {
+      audioStore.songMetadata.tempo = songTempo;
+      audioStore.songMetadata.tempoOffset = songTempoOffset;
+    });
+  }, [audioStore.songMetadata]);
 
   if (!showingBeatGridOverlay) return null;
 
@@ -36,8 +36,8 @@ export const BeatGridOverlay = observer(function BeatGridOverlay() {
       overflow="visible"
     >
       <BeatGrid
-        songTempo={songTempo}
-        songTempoOffset={songTempoOffset}
+        songTempo={audioStore.songMetadata.tempo}
+        songTempoOffset={audioStore.songMetadata.tempoOffset}
         songDuration={audioStore.wavesurfer?.getDuration() ?? 0}
       />
     </Box>

--- a/src/components/BeatGridOverlay.tsx
+++ b/src/components/BeatGridOverlay.tsx
@@ -1,0 +1,45 @@
+import { observer } from "mobx-react-lite";
+import { Box } from "@chakra-ui/react";
+import { useStore } from "@/src/types/StoreContext";
+import { BeatGrid } from "@/src/components/BeatGrid";
+import { useEffect, useState } from "react";
+
+export const BeatGridOverlay = observer(function BeatGridOverlay() {
+  const store = useStore();
+  const { uiStore, audioStore } = store;
+  const { showingBeatGridOverlay } = uiStore;
+
+  const [songTempo, setSongTempo] = useState(120);
+  const [songTempoOffset, setSongTempoOffset] = useState(0);
+
+  useEffect(() => {
+    // TODO: load this from a different source
+    const songMetadata = localStorage.getItem("songMetadata");
+    if (!songMetadata) return;
+
+    const { songTempo, songTempoOffset } = JSON.parse(songMetadata);
+    setSongTempo(songTempo);
+    setSongTempoOffset(songTempoOffset);
+  }, []);
+
+  if (!showingBeatGridOverlay) return null;
+
+  return (
+    <Box
+      position="absolute"
+      top={0}
+      left="150px"
+      width="100%"
+      height="100%"
+      zIndex={1}
+      pointerEvents={"none"}
+      overflow="visible"
+    >
+      <BeatGrid
+        songTempo={songTempo}
+        songTempoOffset={songTempoOffset}
+        songDuration={audioStore.wavesurfer?.getDuration() ?? 0}
+      />
+    </Box>
+  );
+});

--- a/src/components/BeatMapperPage.tsx
+++ b/src/components/BeatMapperPage.tsx
@@ -253,6 +253,7 @@ export const BeatMapperPage = observer(function BeatMapperPage() {
             songTempo={songTempoNumber}
             songTempoOffset={songTempoOffsetNumber}
             songDuration={songDuration}
+            borderColor="red"
           />
         </HStack>
       </Box>

--- a/src/components/Menu/MenuBar.tsx
+++ b/src/components/Menu/MenuBar.tsx
@@ -219,8 +219,11 @@ export const MenuBar = observer(function MenuBar() {
                 <MenuItem as="a" href="/controller" target="_blank">
                   Controller
                 </MenuItem>
-                <MenuItem as="a" href="/viewer" target="_blank">
-                  Viewer
+                <MenuItem as="a" href="/portal" target="_blank">
+                  Portal
+                </MenuItem>
+                <MenuItem as="a" href="/beatMapper" target="_blank">
+                  Beat Mapper
                 </MenuItem>
               </MenuList>
             </Menu>

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -10,10 +10,12 @@ import { TimelineLayer } from "@/src/components/TimelineLayer";
 import { TimerReadout } from "@/src/components/TimerReadout";
 import { MarkerEditorModal } from "@/src/components/MarkerEditorModal";
 import { TimerControls } from "@/src/components/TimerControls";
+import { BeatGrid } from "@/src/components/BeatGrid";
+import { BeatGridOverlay } from "@/src/components/BeatGridOverlay";
 
 export const Timeline = observer(function Timeline() {
   const store = useStore();
-  const { uiStore } = store;
+  const { uiStore, audioStore } = store;
   const timelineRef = useRef<HTMLDivElement>(null);
 
   useWheelZooming(timelineRef.current);
@@ -57,6 +59,7 @@ export const Timeline = observer(function Timeline() {
       {store.context !== "viewer" && (
         <VStack position="relative" alignItems="flex-start" spacing={0}>
           <PlayHead />
+          <BeatGridOverlay />
           {store.layers.map((layer, index) => (
             <TimelineLayer key={index} index={index} layer={layer} />
           ))}

--- a/src/components/TimelineBlockBound.tsx
+++ b/src/components/TimelineBlockBound.tsx
@@ -3,33 +3,48 @@ import { useStore } from "@/src/types/StoreContext";
 import { Box } from "@chakra-ui/react";
 import { action } from "mobx";
 import { observer } from "mobx-react-lite";
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import Draggable, { DraggableData, DraggableEvent } from "react-draggable";
 
 type TimelineBlockProps = {
   block: Block;
-  leftBound?: boolean;
-  rightBound?: boolean;
+  bound: "left" | "right";
 };
 
 export const TimelineBlockBound = observer(function TimelineBlockBound({
   block,
-  leftBound,
-  rightBound,
+  bound,
 }: TimelineBlockProps) {
   const store = useStore();
-  const { uiStore } = store;
+  const { uiStore, audioStore } = store;
 
   const dragNodeRef = useRef(null);
   const [dragging, setDragging] = useState(false);
   const [position, setPosition] = useState({ x: 0, y: 0 });
-  const handleDrag = (e: DraggableEvent, data: DraggableData) => {
-    setPosition({ x: data.x, y: 0 });
-  };
+  const handleDrag = useCallback(
+    (e: DraggableEvent, data: DraggableData) => {
+      if (!uiStore.snappingToBeatGrid) {
+        setPosition({ x: data.x, y: 0 });
+        return;
+      }
+
+      if (bound === "left") {
+        const hoveredTime = uiStore.xToTime(data.x) + block.startTime;
+        console.log(hoveredTime);
+        const nearestBeatTime =
+          audioStore.songMetadata.nearestBeatTime(hoveredTime);
+        const deltaTime = nearestBeatTime - block.startTime;
+        const deltaPosition = uiStore.timeToX(deltaTime);
+        setPosition({ x: deltaPosition, y: 0 });
+      }
+    },
+    [uiStore, audioStore, block, bound]
+  );
 
   const changeBound = (delta: number) => {
-    if (leftBound) block.layer?.resizeBlockLeftBound(block, delta);
-    else if (rightBound) block.layer?.resizeBlockRightBound(block, delta);
+    if (bound === "left") block.layer?.resizeBlockLeftBound(block, delta);
+    else if (bound === "right")
+      block.layer?.resizeBlockRightBound(block, delta);
   };
   const handleStop = action(() => {
     changeBound(uiStore.xToTime(position.x));
@@ -49,8 +64,8 @@ export const TimelineBlockBound = observer(function TimelineBlockBound({
       <Box
         ref={dragNodeRef}
         position="absolute"
-        left={leftBound ? 0 : "auto"}
-        right={rightBound ? 0 : "auto"}
+        left={bound === "left" ? 0 : "auto"}
+        right={bound === "right" ? 0 : "auto"}
         zIndex={2}
         width="5px"
         height="100%"
@@ -59,8 +74,8 @@ export const TimelineBlockBound = observer(function TimelineBlockBound({
         bgColor={dragging ? "gray.100" : "none"}
         onDoubleClick={() => {
           // on double click, snap bound to closest valid time 30s in whichever direction
-          if (leftBound) changeBound(-30);
-          else if (rightBound) changeBound(30);
+          if (bound === "left") changeBound(-30);
+          else if (bound === "right") changeBound(30);
         }}
       />
     </Draggable>

--- a/src/components/TimelineBlockStack.tsx
+++ b/src/components/TimelineBlockStack.tsx
@@ -45,22 +45,22 @@ export const TimelineBlockStack = observer(function TimelineBlockStack({
 
   const lastMouseDown = useRef(0);
 
-  const [snapping, setSnapping] = useState(true);
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const handleDrag = useCallback(
     (e: DraggableEvent, data: DraggableData) => {
-      if (snapping) {
-        // TODO: implement optional snapping here
-        const hoveredTime = uiStore.xToTime(data.x) + patternBlock.startTime;
-        const nearestBeatTime =
-          audioStore.songMetadata.nearestBeat(hoveredTime);
-        const deltaTime = nearestBeatTime - hoveredTime;
-        setPosition({ x: uiStore.timeToX(deltaTime), y: 0 });
+      if (!uiStore.snappingToBeatGrid) {
+        setPosition({ x: data.x, y: 0 });
         return;
       }
-      setPosition({ x: data.x, y: 0 });
+
+      const hoveredTime = uiStore.xToTime(data.x) + patternBlock.startTime;
+      const nearestBeatTime =
+        audioStore.songMetadata.nearestBeatTime(hoveredTime);
+      const deltaTime = nearestBeatTime - patternBlock.startTime;
+      const deltaPosition = uiStore.timeToX(deltaTime);
+      setPosition({ x: deltaPosition, y: 0 });
     },
-    [snapping, uiStore, audioStore, patternBlock]
+    [uiStore, audioStore, patternBlock]
   );
   // handle moving a block to a new start time
   const handleDragStop = action((e: DraggableEvent, data: DraggableData) => {

--- a/src/components/TimelineBlockStack.tsx
+++ b/src/components/TimelineBlockStack.tsx
@@ -140,8 +140,8 @@ export const TimelineBlockStack = observer(function TimelineBlockStack({
         alignItems="center"
         onClick={(e: ReactMouseEvent) => e.stopPropagation()}
       >
-        <TimelineBlockBound block={patternBlock} leftBound />
-        <TimelineBlockBound block={patternBlock} rightBound />
+        <TimelineBlockBound block={patternBlock} bound="left" />
+        <TimelineBlockBound block={patternBlock} bound="right" />
 
         <PatternOrEffectBlock
           block={patternBlock}

--- a/src/components/TimelineBlockStack.tsx
+++ b/src/components/TimelineBlockStack.tsx
@@ -25,7 +25,7 @@ export const TimelineBlockStack = observer(function TimelineBlockStack({
   patternBlock,
 }: Props) {
   const store = useStore();
-  const { selectedBlocksOrVariations, uiStore } = store;
+  const { selectedBlocksOrVariations, uiStore, audioStore } = store;
 
   const dragNodeRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -45,11 +45,23 @@ export const TimelineBlockStack = observer(function TimelineBlockStack({
 
   const lastMouseDown = useRef(0);
 
+  const [snapping, setSnapping] = useState(true);
   const [position, setPosition] = useState({ x: 0, y: 0 });
-  const handleDrag = useCallback((e: DraggableEvent, data: DraggableData) => {
-    // TODO: implement optional snapping here
-    setPosition({ x: data.x, y: 0 });
-  }, []);
+  const handleDrag = useCallback(
+    (e: DraggableEvent, data: DraggableData) => {
+      if (snapping) {
+        // TODO: implement optional snapping here
+        const hoveredTime = uiStore.xToTime(data.x) + patternBlock.startTime;
+        const nearestBeatTime =
+          audioStore.songMetadata.nearestBeat(hoveredTime);
+        const deltaTime = nearestBeatTime - hoveredTime;
+        setPosition({ x: uiStore.timeToX(deltaTime), y: 0 });
+        return;
+      }
+      setPosition({ x: data.x, y: 0 });
+    },
+    [snapping, uiStore, audioStore, patternBlock]
+  );
   // handle moving a block to a new start time
   const handleDragStop = action((e: DraggableEvent, data: DraggableData) => {
     if (Math.abs(position.x) < 1) return;

--- a/src/components/VariationBound.tsx
+++ b/src/components/VariationBound.tsx
@@ -25,27 +25,24 @@ export const VariationBound = memo(function VariationBound({
   const dragNodeRef = useRef(null);
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const handleDrag = useCallback(
-    (e: DraggableEvent, data: DraggableData) => {
-      if (!uiStore.snappingToBeatGrid) {
-        setPosition({ x: data.x, y: 0 });
-        return;
-      }
-
-      // const hoveredTime = uiStore.xToTime(data.x) + patternBlock.startTime;
-      // const nearestBeatTime =
-      //   audioStore.songMetadata.nearestBeatTime(hoveredTime);
-      // const deltaTime = nearestBeatTime - patternBlock.startTime;
-      // const deltaPosition = uiStore.timeToX(deltaTime);
-      // setPosition({ x: deltaPosition, y: 0 });
-    },
-    [uiStore, audioStore]
+    (e: DraggableEvent, data: DraggableData) =>
+      setPosition({ x: data.x, y: 0 }),
+    []
   );
   const handleStop = action(() => {
-    block.applyVariationDurationDelta(
-      uniformName,
-      variation,
-      store.uiStore.xToTime(position.x)
-    );
+    let deltaTime = uiStore.xToTime(position.x);
+    if (uiStore.snappingToBeatGrid) {
+      const variationEndTime = block.getVariationGlobalEndTime(
+        uniformName,
+        variation
+      );
+      const hoveredTime = uiStore.xToTime(position.x) + variationEndTime;
+      const nearestBeatTime =
+        audioStore.songMetadata.nearestBeatTime(hoveredTime);
+      deltaTime = nearestBeatTime - variationEndTime;
+    }
+
+    block.applyVariationDurationDelta(uniformName, variation, deltaTime);
     setPosition({ x: 0, y: 0 });
   });
   const handleDoubleClick = action(() => {

--- a/src/components/VariationBound.tsx
+++ b/src/components/VariationBound.tsx
@@ -1,6 +1,6 @@
 import { ExtraParams } from "@/src/types/PatternParams";
 import { Box } from "@chakra-ui/react";
-import { memo, useRef, useState } from "react";
+import { memo, useCallback, useRef, useState } from "react";
 import { Variation } from "@/src/types/Variations/Variation";
 import Draggable, { DraggableData, DraggableEvent } from "react-draggable";
 import { useStore } from "@/src/types/StoreContext";
@@ -20,12 +20,26 @@ export const VariationBound = memo(function VariationBound({
   variation,
 }: ParameterProps) {
   const store = useStore();
+  const { uiStore, audioStore } = store;
 
   const dragNodeRef = useRef(null);
   const [position, setPosition] = useState({ x: 0, y: 0 });
-  const handleDrag = (e: DraggableEvent, data: DraggableData) => {
-    setPosition({ x: data.x, y: 0 });
-  };
+  const handleDrag = useCallback(
+    (e: DraggableEvent, data: DraggableData) => {
+      if (!uiStore.snappingToBeatGrid) {
+        setPosition({ x: data.x, y: 0 });
+        return;
+      }
+
+      // const hoveredTime = uiStore.xToTime(data.x) + patternBlock.startTime;
+      // const nearestBeatTime =
+      //   audioStore.songMetadata.nearestBeatTime(hoveredTime);
+      // const deltaTime = nearestBeatTime - patternBlock.startTime;
+      // const deltaPosition = uiStore.timeToX(deltaTime);
+      // setPosition({ x: deltaPosition, y: 0 });
+    },
+    [uiStore, audioStore]
+  );
   const handleStop = action(() => {
     block.applyVariationDurationDelta(
       uniformName,

--- a/src/types/AudioStore.ts
+++ b/src/types/AudioStore.ts
@@ -14,6 +14,7 @@ import type MinimapPlugin from "wavesurfer.js/dist/plugins/minimap";
 import type { RegionParams } from "wavesurfer.js/dist/plugins/regions";
 import { filterData } from "@/src/types/audioPeaks";
 import { AudioRegion } from "@/src/types/AudioRegion";
+import { SongMetadata } from "@/src/types/SongMetadata";
 
 export const loopRegionColor = "rgba(237, 137, 54, 0.4)";
 
@@ -47,6 +48,8 @@ export class AudioStore {
   audioState: "paused" | "starting" | "playing" = "paused";
 
   audioContext: AudioContext | null = null;
+
+  songMetadata = new SongMetadata(120, 0);
 
   constructor(readonly rootStore: RootStore) {
     makeAutoObservable(this, {

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -216,6 +216,19 @@ export class Block<T extends ExtraParams = {}> {
     if (index > -1) variations.splice(index, 0, variation.clone());
   };
 
+  // Note: not berry performant due to looping through variations
+  getVariationGlobalEndTime = (uniformName: string, variation: Variation) => {
+    const variations = this.parameterVariations[uniformName];
+    if (!variations) return this.startTime;
+
+    const index = variations.indexOf(variation);
+    if (index < 0) return this.startTime;
+
+    return variations
+      .slice(0, index + 1)
+      .reduce((total, variation) => total + variation.duration, 0);
+  };
+
   applyVariationDurationDelta = (
     uniformName: string,
     variation: Variation,

--- a/src/types/SongMetadata.ts
+++ b/src/types/SongMetadata.ts
@@ -15,8 +15,13 @@ export class SongMetadata {
     return 60 / this.tempo;
   }
 
-  nearestBeat = (time: number) =>
-    Math.floor((time - this.tempoOffset) / this.beatDuration) *
-      this.beatDuration +
-    this.tempoOffset;
+  nearestBeatTime = (time: number) =>
+    Math.max(
+      0,
+      Math.floor(
+        (time - this.tempoOffset + this.beatDuration / 2) / this.beatDuration
+      ) *
+        this.beatDuration +
+        this.tempoOffset
+    );
 }

--- a/src/types/SongMetadata.ts
+++ b/src/types/SongMetadata.ts
@@ -1,0 +1,22 @@
+import { makeAutoObservable } from "mobx";
+
+export class SongMetadata {
+  tempo: number;
+  tempoOffset: number;
+
+  constructor(tempo: number, tempoOffset: number) {
+    this.tempo = tempo;
+    this.tempoOffset = tempoOffset;
+
+    makeAutoObservable(this);
+  }
+
+  get beatDuration() {
+    return 60 / this.tempo;
+  }
+
+  nearestBeat = (time: number) =>
+    Math.floor((time - this.tempoOffset) / this.beatDuration) *
+      this.beatDuration +
+    this.tempoOffset;
+}

--- a/src/types/UIStore.ts
+++ b/src/types/UIStore.ts
@@ -24,7 +24,8 @@ export class UIStore {
   horizontalLayout = true;
   showingPerformance = false;
   showingWaveformOverlay = false;
-  showingBeatGridOverlay = true;
+  showingBeatGridOverlay = false;
+  snappingToBeatGrid = false;
   showingOpenExperienceModal = false;
   showingSaveExperienceModal = false;
   showingUploadAudioModal = false;
@@ -110,6 +111,10 @@ export class UIStore {
 
   toggleBeatGridOverlay = () => {
     this.showingBeatGridOverlay = !this.showingBeatGridOverlay;
+  };
+
+  toggleSnappingToBeatGrid = () => {
+    this.snappingToBeatGrid = !this.snappingToBeatGrid;
   };
 
   nextRenderTextureSize = () => {

--- a/src/types/UIStore.ts
+++ b/src/types/UIStore.ts
@@ -24,6 +24,7 @@ export class UIStore {
   horizontalLayout = true;
   showingPerformance = false;
   showingWaveformOverlay = false;
+  showingBeatGridOverlay = false;
   showingOpenExperienceModal = false;
   showingSaveExperienceModal = false;
   showingUploadAudioModal = false;
@@ -105,6 +106,10 @@ export class UIStore {
 
   toggleWaveformOverlay = () => {
     this.showingWaveformOverlay = !this.showingWaveformOverlay;
+  };
+
+  toggleBeatGridOverlay = () => {
+    this.showingBeatGridOverlay = !this.showingBeatGridOverlay;
   };
 
   nextRenderTextureSize = () => {

--- a/src/types/UIStore.ts
+++ b/src/types/UIStore.ts
@@ -24,7 +24,7 @@ export class UIStore {
   horizontalLayout = true;
   showingPerformance = false;
   showingWaveformOverlay = false;
-  showingBeatGridOverlay = false;
+  showingBeatGridOverlay = true;
   showingOpenExperienceModal = false;
   showingSaveExperienceModal = false;
   showingUploadAudioModal = false;


### PR DESCRIPTION
![image](https://github.com/SotSF/conjurer/assets/12655228/2c820170-f39f-440b-949b-f796ad20ee67)

Now blocks and variations can be snapped to a beat grid!