### PR TITLE
`SpaceOdyssey` pattern, support manual timing configuration

### DIFF
--- a/src/components/PatternOrEffectBlock.tsx
+++ b/src/components/PatternOrEffectBlock.tsx
@@ -11,6 +11,7 @@ import { FaTrashAlt } from "react-icons/fa";
 import { HeaderRepeat } from "@/src/components/HeaderRepeat";
 import { ImLoop } from "react-icons/im";
 import { useStore } from "@/src/types/StoreContext";
+import PatternTimingModal from "./PatternTimingModal";
 
 type Props = {
   block: Block;
@@ -60,7 +61,7 @@ export const PatternOrEffectBlock = observer(function PatternOrEffectBlock({
             userSelect="none"
             textOverflow="clip"
             overflowWrap="anywhere"
-            color={color}
+            color="blue.500"
           >
             {isEffect ? "Effect" : "Pattern"}: {block.pattern.name}
           </Heading>
@@ -96,6 +97,7 @@ export const PatternOrEffectBlock = observer(function PatternOrEffectBlock({
               e.stopPropagation();
             }}
           />
+          {!isEffect && <PatternTimingModal block={block} />}
           {isEffect && (
             <HStack position="absolute" right={0}>
               {effectIndex < lastEffectIndex && (

--- a/src/components/PatternTimingModal.tsx
+++ b/src/components/PatternTimingModal.tsx
@@ -1,0 +1,124 @@
+import {
+  Button,
+  IconButton,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  VStack,
+  useDisclosure,
+} from "@chakra-ui/react";
+import { ImClock } from "react-icons/im";
+import { Block } from "../types/Block";
+import { ScalarInput } from "./ScalarInput";
+import { useMemo, useState } from "react";
+
+type PatternTimingModalProps = {
+  block: Block;
+};
+
+export default function PatternTimingModal({ block }: PatternTimingModalProps) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [startTime, setStartTime] = useState(block.startTime.toString());
+  const [endTime, setEndTime] = useState(block.endTime.toString());
+  const [duration, setDuration] = useState(block.duration.toString());
+
+  const isValid = useMemo(() => {
+    const startTimeNumber = parseFloat(startTime);
+    const endTimeNumber = parseFloat(endTime);
+    const durationNumber = parseFloat(duration);
+
+    return (
+      !isNaN(startTimeNumber) &&
+      !isNaN(endTimeNumber) &&
+      !isNaN(durationNumber) &&
+      startTimeNumber >= 0 &&
+      endTimeNumber > startTimeNumber &&
+      durationNumber > 0
+    );
+  }, [startTime, endTime, duration]);
+
+  return (
+    <>
+      <IconButton
+        variant="ghost"
+        size="xs"
+        aria-label="Timing"
+        title="Timing"
+        height={6}
+        icon={<ImClock size={15} />}
+        onClick={onOpen}
+      />
+
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Adjust Pattern Timing</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <VStack spacing={4}>
+              <ScalarInput
+                name="Start time (s)"
+                onChange={(valueString, valueNumber) => {
+                  setStartTime(valueString);
+                  if (!isNaN(valueNumber) && valueNumber > 0) {
+                    if (valueNumber > +endTime) {
+                      setEndTime((valueNumber + +duration).toString());
+                    } else {
+                      setDuration((+endTime - valueNumber).toString());
+                    }
+                  }
+                }}
+                value={startTime}
+              />
+
+              <ScalarInput
+                name="End time (s)"
+                onChange={(valueString, valueNumber) => {
+                  setEndTime(valueString);
+                  if (!isNaN(valueNumber) && valueNumber > +startTime) {
+                    setDuration((valueNumber - +startTime).toString());
+                  }
+                }}
+                value={endTime}
+              />
+
+              <ScalarInput
+                name="Duration (s)"
+                onChange={(valueString, valueNumber) => {
+                  setDuration(valueString);
+                  if (!isNaN(valueNumber) && valueNumber > 0) {
+                    setEndTime((+startTime + valueNumber).toString());
+                  }
+                }}
+                value={duration}
+              />
+            </VStack>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button variant="ghost" mr={3} onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              colorScheme="blue"
+              isDisabled={!isValid}
+              onClick={() => {
+                onClose();
+                block.setTiming({
+                  startTime: parseFloat(startTime),
+                  duration: parseFloat(duration),
+                });
+              }}
+            >
+              Apply
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/PatternTimingModal.tsx
+++ b/src/components/PatternTimingModal.tsx
@@ -1,3 +1,5 @@
+import { useMemo, useState } from "react";
+import { ImClock } from "react-icons/im";
 import {
   Button,
   IconButton,
@@ -11,10 +13,9 @@ import {
   VStack,
   useDisclosure,
 } from "@chakra-ui/react";
-import { ImClock } from "react-icons/im";
+
 import { Block } from "../types/Block";
 import { ScalarInput } from "./ScalarInput";
-import { useMemo, useState } from "react";
 
 type PatternTimingModalProps = {
   block: Block;

--- a/src/components/VariationControls/VariationControls.tsx
+++ b/src/components/VariationControls/VariationControls.tsx
@@ -314,18 +314,22 @@ export function PeriodicVariationControls({
           <ScalarInput
             name="Min"
             onChange={(valueString, valueNumber) => {
-              variation.min = valueNumber;
               setMin(valueString);
-              block.triggerVariationReactions(uniformName);
+              if (!isNaN(valueNumber)) {
+                variation.min = valueNumber;
+                block.triggerVariationReactions(uniformName);
+              }
             }}
             value={min}
           />
           <ScalarInput
             name="Max"
             onChange={(valueString, valueNumber) => {
-              variation.max = valueNumber;
               setMax(valueString);
-              block.triggerVariationReactions(uniformName);
+              if (!isNaN(valueNumber)) {
+                variation.max = valueNumber;
+                block.triggerVariationReactions(uniformName);
+              }
             }}
             value={max}
           />

--- a/src/patterns/SpaceOdyssey.ts
+++ b/src/patterns/SpaceOdyssey.ts
@@ -1,0 +1,31 @@
+import { Pattern } from "@/src/types/Pattern";
+import { Palette } from "@/src/types/Palette";
+import { Vector3 } from "three";
+
+import spaceOdyssey from "@/src/patterns/shaders/spaceOdyssey.frag";
+
+export { spaceOdyssey };
+export const SpaceOdyssey = () =>
+  new Pattern("SpaceOdyssey", spaceOdyssey, {
+    u_palette: {
+      name: "Palette",
+      value: new Palette(
+        new Vector3(0.261, 0.446, 0.315),
+        new Vector3(0.843, 0.356, 0.239),
+        new Vector3(0.948, 1.474, 1.361),
+        new Vector3(3.042, 5.63, 5.424)
+      ),
+    },
+    u_iterations: {
+      name: "Iterations",
+      value: 4,
+    },
+    u_exponent: {
+      name: "Exponent",
+      value: 1.2,
+    },
+    u_color_change_rate: {
+      name: "Color Change Rate",
+      value: 0.4,
+    },
+  });

--- a/src/patterns/SpaceOdyssey.ts
+++ b/src/patterns/SpaceOdyssey.ts
@@ -1,8 +1,8 @@
-import { Pattern } from "@/src/types/Pattern";
-import { Palette } from "@/src/types/Palette";
 import { Vector3 } from "three";
 
 import spaceOdyssey from "@/src/patterns/shaders/spaceOdyssey.frag";
+import { Pattern } from "@/src/types/Pattern";
+import { Palette } from "@/src/types/Palette";
 
 export { spaceOdyssey };
 export const SpaceOdyssey = () =>

--- a/src/patterns/patterns.ts
+++ b/src/patterns/patterns.ts
@@ -14,6 +14,7 @@ import { Melt } from "@/src/patterns/Melt";
 import { Tunnel } from "@/src/patterns/Tunnel";
 import { Rainbow } from "@/src/patterns/Rainbow";
 import { Starfield } from "@/src/patterns/Starfield";
+import { SpaceOdyssey } from "@/src/patterns/SpaceOdyssey";
 import { Globules } from "@/src/patterns/Globules";
 import { Construct } from "@/src/patterns/Construct";
 import { EasternRedbud } from "@/src/patterns/EasternRedbud";
@@ -38,6 +39,7 @@ const patternFactories: Array<() => Pattern> = [
   Pulse,
   Rainbow,
   Starfield,
+  SpaceOdyssey,
   SunCycle,
   Tunnel,
   Construct,

--- a/src/patterns/shaders/spaceOdyssey.frag
+++ b/src/patterns/shaders/spaceOdyssey.frag
@@ -1,0 +1,34 @@
+#include <conjurer_common>
+
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+varying vec2 v_uv;
+uniform float u_time;
+uniform float u_iterations;
+uniform float u_exponent;
+uniform float u_color_change_rate;
+
+uniform Palette u_palette;
+
+void main() {
+    vec2 st = v_uv;
+    vec2 st0 = st;
+    vec3 finalColor = vec3(0.0);
+
+    for (float i = 0.; i < u_iterations; i++) {
+        st = fract(st * 1.5) - 0.5;
+
+        float d = length(st) * exp(-length(st0));
+        d = sin(d * 8. + u_time) / 8.;
+        d = abs(d);
+        d = pow(0.01 / d, u_exponent);
+
+        vec3 col = palette(length(st0) + i * 0.4 + u_time * u_color_change_rate, u_palette);
+        finalColor += col * d;
+    }
+
+
+    gl_FragColor = vec4(finalColor, 1.0);
+}

--- a/src/shaders/conjurer_common.frag
+++ b/src/shaders/conjurer_common.frag
@@ -69,7 +69,7 @@ float plot(vec2 st, float pct) {
 //   x goes from 0.0 to 1.0, which describes the angle around the center from 0 to 2pi
 //   y goes from 0.0 to 1.0, which describes the distance from the apex to the edge of the canopy
 
-// Cannot be coordinate can be useful to write patterns so that you can described behavior with the
+// Canopy coordinates can be useful to write patterns so that you can describe behavior with the
 // boundaries of the canopy in mind. However, the coordinate space being so specialized can be
 // limiting. Use the functions below to convert to other coordinate systems whenever desired.
 

--- a/src/types/Variations/PeriodicVariation.ts
+++ b/src/types/Variations/PeriodicVariation.ts
@@ -15,8 +15,7 @@ export class PeriodicVariation extends Variation<number> {
   }
 
   set min(newMin: number) {
-    const oldMax = this.max;
-    this.amplitude = (oldMax - newMin) / 2;
+    this.amplitude = (this.max - newMin) / 2;
     this.offset = newMin + this.amplitude;
   }
 


### PR DESCRIPTION
- Introduced a new `SpaceOdyssey` pattern which I ripped off from a YouTube video lulz
- Added the `PatternTimingModal` to make it simpler to specify exactly where in the song a pattern should start/stop. Accessible via a new clock icon in the pattern header
- Made the pattern name always visible (was previously grayed out if the pattern wasn't selected in the UI)
- Fixed an issue with the `PeriodicVariationControls` which could break the component if the user enters a non-numeric string (the component was setting the parameter value to `NaN` when I entered a minus sign, and could not easily recover from it)