### PR TITLE
More butthead astronomer homage

### DIFF
--- a/src/components/AddEffectButton.tsx
+++ b/src/components/AddEffectButton.tsx
@@ -59,7 +59,7 @@ export const AddEffectButton = observer(function AddEffectButton({
           </HStack>
         </MenuButton>
         <Portal>
-          <MenuList>
+          <MenuList rootProps={{ style: { zIndex: 12 } }}>
             {playgroundEffects.map((effect) => (
               <MenuItem
                 key={effect.name}

--- a/src/components/PalletteEditor/PaletteEditor.tsx
+++ b/src/components/PalletteEditor/PaletteEditor.tsx
@@ -5,7 +5,17 @@ import {
   AccordionItem,
   AccordionPanel,
   Box,
+  Center,
+  NumberInput,
+  NumberInputField,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
   Text,
+  Th,
+  Thead,
+  Tr,
 } from "@chakra-ui/react";
 import {
   LineChart,
@@ -23,6 +33,7 @@ import { Block } from "@/src/types/Block";
 import { Palette } from "@/src/types/Palette";
 import { HexColorInput, HexColorPicker } from "react-colorful";
 import { hexToVector3 } from "@/src/utils/color";
+import { Vector3 } from "three";
 
 const samples = 100;
 const getPaletteSeriesData = (palette: Palette) => {
@@ -71,7 +82,7 @@ export const PaletteEditor = memo(function PaletteEditor({
         <PaletteVariationGraph
           uniformName={uniformName}
           variation={variation}
-          width={200}
+          width={300}
           block={block}
         />
         <Button size="xs" onClick={() => randomize()}>
@@ -79,7 +90,7 @@ export const PaletteEditor = memo(function PaletteEditor({
         </Button>
       </HStack>
 
-      <Accordion bgColor="gray.600" maxWidth="325px" allowToggle>
+      <Accordion bgColor="gray.600" allowToggle>
         <AccordionItem>
           <AccordionButton>
             <HStack justify="space-between">
@@ -89,62 +100,172 @@ export const PaletteEditor = memo(function PaletteEditor({
           </AccordionButton>
 
           <AccordionPanel>
-            <PaletteVariationGraph
-              uniformName={uniformName}
-              variation={variation}
-              width={300}
-              block={block}
-            />
-            <LineChart
-              width={300}
-              height={100}
-              margin={{ top: 0, left: 0, right: 0, bottom: 0 }}
-            >
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="t" type="number" hide />
-              <YAxis type="number" domain={[0, 1]} hide allowDataOverflow />
-              {series.map(({ name, data }) => (
-                <Line
-                  key={name}
-                  dot={false}
-                  isAnimationActive={false}
-                  type="monotone"
-                  dataKey="value"
-                  data={data}
-                  name={name}
-                  stroke={name}
-                  strokeWidth={2}
-                />
-              ))}
-              <Tooltip
-                isAnimationActive={false}
-                content={<ColorValuesTooltip />}
-              />
-            </LineChart>
-            <HStack mt={2}>
+            <Center>
               <VStack>
-                <HexColorInput
-                  className="hexColorInput"
-                  color={color}
-                  onChange={setColor}
+                <LineChart
+                  width={300}
+                  height={100}
+                  margin={{ top: 0, left: 0, right: 0, bottom: 0 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="t" type="number" hide />
+                  <YAxis type="number" domain={[0, 1]} hide allowDataOverflow />
+                  {series.map(({ name, data }) => (
+                    <Line
+                      key={name}
+                      dot={false}
+                      isAnimationActive={false}
+                      type="monotone"
+                      dataKey="value"
+                      data={data}
+                      name={name}
+                      stroke={name}
+                      strokeWidth={2}
+                    />
+                  ))}
+                  <Tooltip
+                    isAnimationActive={false}
+                    content={<ColorValuesTooltip />}
+                  />
+                </LineChart>
+                <HStack mt={2}>
+                  <VStack>
+                    <HexColorInput
+                      className="hexColorInput"
+                      color={color}
+                      onChange={setColor}
+                    />
+                    <HexColorPicker color={color} onChange={setColor} />
+                  </VStack>
+                  <VStack>
+                    <Box w="60px" h="60px" bg={color} />
+                    <Button
+                      size="xs"
+                      height={8}
+                      onClick={() => randomize(true)}
+                    >
+                      Randomize
+                      <br />
+                      with color
+                    </Button>
+                  </VStack>
+                </HStack>
+
+                <ManualPaletteEditor
+                  palette={variation.palette}
+                  setPalette={setPalette}
                 />
-                <HexColorPicker color={color} onChange={setColor} />
               </VStack>
-              <VStack>
-                <Box w="60px" h="60px" bg={color} />
-                <Button size="xs" height={8} onClick={() => randomize(true)}>
-                  Randomize
-                  <br />
-                  with color
-                </Button>
-              </VStack>
-            </HStack>
+            </Center>
           </AccordionPanel>
         </AccordionItem>
       </Accordion>
     </VStack>
   );
 });
+
+type ManualPaletteEditorProps = {
+  palette: Palette;
+  setPalette?: (palette: Palette) => void;
+};
+
+const ManualPaletteEditor = ({
+  palette,
+  setPalette,
+}: ManualPaletteEditorProps) => {
+  const onChange = (component: PaletteComponent, color: Vector3) => {
+    palette[component].copy(color);
+    setPalette?.(palette);
+  };
+
+  return (
+    <TableContainer style={{ marginTop: 20 }}>
+      <Table variant="simple" size="sm">
+        <Thead>
+          <Tr>
+            <Th />
+            <Th style={{ textAlign: "center" }}>R</Th>
+            <Th style={{ textAlign: "center" }}>G</Th>
+            <Th style={{ textAlign: "center" }}>B</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          <PaletteColorRow component="a" {...{ palette, onChange }} />
+          <PaletteColorRow component="b" {...{ palette, onChange }} />
+          <PaletteColorRow component="c" {...{ palette, onChange }} />
+          <PaletteColorRow component="d" {...{ palette, onChange }} />
+        </Tbody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+type PaletteComponent = "a" | "b" | "c" | "d";
+type PaletteColorRowProps = {
+  component: PaletteComponent;
+  palette: Palette;
+  onChange: (component: PaletteComponent, color: Vector3) => void;
+};
+
+const PaletteColorRow = ({
+  component,
+  palette,
+  onChange: handleChange,
+}: PaletteColorRowProps) => {
+  const onChange = (newColor: Vector3) => handleChange(component, newColor);
+  const data = palette[component];
+  return (
+    <Tr>
+      <Td>{component.toUpperCase()}</Td>
+      <PaletteColorComponent color="r" {...{ data, onChange }} />
+      <PaletteColorComponent color="g" {...{ data, onChange }} />
+      <PaletteColorComponent color="b" {...{ data, onChange }} />
+    </Tr>
+  );
+};
+
+type ColorComponent = "r" | "g" | "b";
+type PaletteColorComponentProps = {
+  data: Vector3;
+  color: ColorComponent;
+  onChange: (newColor: Vector3) => void;
+};
+
+const vectorAccessorMap = {
+  r: "x",
+  g: "y",
+  b: "z",
+} as const;
+
+const PaletteColorComponent = ({
+  data,
+  color,
+  onChange,
+}: PaletteColorComponentProps) => {
+  const vectorAccessor = vectorAccessorMap[color];
+  const [strValue, setStrValue] = useState(data[vectorAccessor].toFixed(5));
+
+  return (
+    <Td>
+      <NumberInput
+        size="sm"
+        min={0}
+        max={1}
+        value={strValue}
+        onChange={(valueString, valueNumber) => {
+          setStrValue(valueString);
+          if (!isNaN(valueNumber)) {
+            const newColor = data.clone();
+            newColor[vectorAccessor] = valueNumber;
+            onChange(newColor);
+          }
+        }}
+      >
+        <NumberInputField />
+      </NumberInput>
+    </Td>
+  );
+};
 
 const ColorValuesTooltip = ({
   active,

--- a/src/components/PatternOrEffectBlock.tsx
+++ b/src/components/PatternOrEffectBlock.tsx
@@ -61,7 +61,7 @@ export const PatternOrEffectBlock = observer(function PatternOrEffectBlock({
             userSelect="none"
             textOverflow="clip"
             overflowWrap="anywhere"
-            color="blue.500"
+            color={color}
           >
             {isEffect ? "Effect" : "Pattern"}: {block.pattern.name}
           </Heading>

--- a/src/effects/shaders/colorTint.frag
+++ b/src/effects/shaders/colorTint.frag
@@ -19,6 +19,5 @@ void main() {
     vec4 mixed = mix(sampled, u_color, u_intensity);
 
     // any sampled pixels that are black, leave them black
-    mixed.xyz = step(0.000001, sampled.x * sampled.y * sampled.z) * mixed.xyz;
-    gl_FragColor = mixed;
+    gl_FragColor = sampled.rgb == vec3(0.) ? sampled : mixed;
 }

--- a/src/patterns/GalaxyTour.ts
+++ b/src/patterns/GalaxyTour.ts
@@ -7,15 +7,6 @@ import galaxyTour from "@/src/patterns/shaders/galaxyTour.frag";
 export { galaxyTour };
 export const GalaxyTour = () =>
   new Pattern("GalaxyTour", galaxyTour, {
-    u_palette: {
-      name: "Palette",
-      value: new Palette(
-        new Vector3(0.261, 0.446, 0.315),
-        new Vector3(0.843, 0.356, 0.239),
-        new Vector3(0.948, 1.474, 1.361),
-        new Vector3(3.042, 5.63, 5.424)
-      ),
-    },
     u_iterations: {
       name: "Star Density",
       value: 12,

--- a/src/patterns/GalaxyTour.ts
+++ b/src/patterns/GalaxyTour.ts
@@ -1,0 +1,97 @@
+import { Pattern } from "@/src/types/Pattern";
+import { Palette } from "@/src/types/Palette";
+import { Vector3, Vector4 } from "three";
+
+import galaxyTour from "@/src/patterns/shaders/galaxyTour.frag";
+
+export { galaxyTour };
+export const GalaxyTour = () =>
+  new Pattern("GalaxyTour", galaxyTour, {
+    u_palette: {
+      name: "Palette",
+      value: new Palette(
+        new Vector3(0.261, 0.446, 0.315),
+        new Vector3(0.843, 0.356, 0.239),
+        new Vector3(0.948, 1.474, 1.361),
+        new Vector3(3.042, 5.63, 5.424)
+      ),
+    },
+    u_iterations: {
+      name: "Star Density",
+      value: 12,
+      min: 1,
+      max: 40,
+    },
+    u_magic: {
+      name: "Magic",
+      value: 0.79,
+      min: 0,
+      max: 1.2,
+    },
+    u_dark_stars: {
+      name: "Dark Stars",
+      value: 0,
+      min: 0,
+      max: 1,
+      step: 1,
+    },
+    u_zoom: {
+      name: "Zoom",
+      value: 1.0,
+      min: 0.1,
+      max: 5,
+    },
+    u_step_size: {
+      name: "Step Size",
+      value: 0.29,
+      min: 0.001,
+      max: 1,
+    },
+    u_speed: {
+      name: "Forward Speed",
+      value: 0.2,
+      min: 0.1,
+      max: 4,
+    },
+    u_transverse_speed: {
+      name: "Transverse Speed",
+      value: 1,
+      min: -10,
+      max: 10,
+    },
+    u_brightness: {
+      name: "Brightness",
+      value: 1.5,
+      min: 0,
+      max: 100,
+    },
+    u_visible_distance: {
+      name: "Visible Distance",
+      value: 7,
+      min: 1,
+      max: 10,
+      step: 1,
+    },
+    u_dist_fading: {
+      name: "Distance Fading",
+      value: 0.56,
+      min: 0,
+      max: 1,
+    },
+    u_saturation: {
+      name: "Saturation",
+      value: 0.9,
+      min: 0,
+      max: 1,
+    },
+    u_cloud: {
+      name: "Cloud",
+      value: 0.17,
+      min: 0,
+      max: 1,
+    },
+    u_cloud_color: {
+      name: "Cloud Color",
+      value: new Vector4(0.05, 0, 1.8),
+    },
+  });

--- a/src/patterns/GentleRings.ts
+++ b/src/patterns/GentleRings.ts
@@ -1,0 +1,19 @@
+import { Pattern } from "@/src/types/Pattern";
+import { Palette } from "@/src/types/Palette";
+import { Vector3 } from "three";
+
+import gentleRings from "@/src/patterns/shaders/gentleRings.frag";
+
+export { gentleRings };
+export const GentleRings = () =>
+  new Pattern("GentleRings", gentleRings, {
+    u_palette: {
+      name: "Palette",
+      value: new Palette(
+        new Vector3(0.5, 0.5, 0.5),
+        new Vector3(0.5, 0.5, 0.5),
+        new Vector3(1, 1, 1),
+        new Vector3(0, 0.33, 0.67)
+      ),
+    },
+  });

--- a/src/patterns/Lightwaves.ts
+++ b/src/patterns/Lightwaves.ts
@@ -24,6 +24,11 @@ export const Lightwaves = () =>
       name: "Time Factor",
       value: 0,
     },
+    u_timeOffset: {
+      name: "Time Offset",
+      value: 0,
+      max: 40,
+    },
     u_period: {
       name: "Period",
       value: 0,

--- a/src/patterns/patterns.ts
+++ b/src/patterns/patterns.ts
@@ -15,6 +15,7 @@ import { Melt } from "@/src/patterns/Melt";
 import { Tunnel } from "@/src/patterns/Tunnel";
 import { Rainbow } from "@/src/patterns/Rainbow";
 import { Starfield } from "@/src/patterns/Starfield";
+import { GalaxyTour } from "@/src/patterns/GalaxyTour";
 import { SpaceOdyssey } from "@/src/patterns/SpaceOdyssey";
 import { Globules } from "@/src/patterns/Globules";
 import { Construct } from "@/src/patterns/Construct";
@@ -40,6 +41,7 @@ const patternFactories: Array<() => Pattern> = [
   Perlin,
   Pulse,
   Rainbow,
+  GalaxyTour,
   Starfield,
   SpaceOdyssey,
   SunCycle,

--- a/src/patterns/patterns.ts
+++ b/src/patterns/patterns.ts
@@ -6,6 +6,7 @@ import { Pattern } from "@/src/types/Pattern";
 import { Clouds } from "@/src/patterns/Clouds";
 import { Disc } from "@/src/patterns/Disc";
 import { SunCycle } from "@/src/patterns/SunCycle";
+import { GentleRings } from "@/src/patterns/GentleRings";
 import { LogSpirals } from "@/src/patterns/LogSpirals";
 import { Barcode } from "@/src/patterns/Barcode";
 import { Pulse } from "@/src/patterns/Pulse";
@@ -31,6 +32,7 @@ const patternFactories: Array<() => Pattern> = [
   Clouds,
   Disc,
   Fire,
+  GentleRings,
   Globules,
   GradientCircles,
   Lissajous,

--- a/src/patterns/shaders/galaxyTour.frag
+++ b/src/patterns/shaders/galaxyTour.frag
@@ -8,8 +8,6 @@ precision mediump float;
 varying vec2 v_uv;
 uniform float u_time;
 
-uniform Palette u_palette;
-
 uniform int u_iterations;
 uniform float u_magic;
 uniform float u_step_size;

--- a/src/patterns/shaders/galaxyTour.frag
+++ b/src/patterns/shaders/galaxyTour.frag
@@ -1,0 +1,169 @@
+// From https://godotshaders.com/shader/starfield/, credit to https://godotshaders.com/author/ivader/
+#include <conjurer_common>
+
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+varying vec2 v_uv;
+uniform float u_time;
+
+uniform Palette u_palette;
+
+uniform int u_iterations;
+uniform float u_magic;
+uniform float u_step_size;
+uniform bool u_dark_stars;
+uniform float u_visible_distance;
+uniform float u_zoom;
+uniform float u_speed;
+uniform float u_brightness;
+uniform float u_dist_fading;
+uniform float u_saturation;
+uniform float u_transverse_speed;
+uniform float u_cloud;
+uniform vec3 u_cloud_color;
+
+
+const float tileScale = 0.850;
+
+
+float triangle(float x, float a) { 
+	float output2 = 2.0*abs(  3.0*  ( (x/a) - floor( (x/a) + 0.5) ) ) - 1.0;
+	return output2;
+}
+ 
+float field(in vec3 p) {	
+	float strength = 7. + .03 * log(1.e-6 + fract(sin(u_time) * 373.11));
+	float accum = 0.;
+	float prev = 0.;
+	float tw = 0.;	
+
+	for (int i = 0; i < 6; ++i) {
+		float mag = dot(p, p);
+		p = abs(p) / mag + vec3(-.5, -.8 + 0.1*sin(-u_time*0.1 + 2.0), -1.1+0.3*cos(u_time*0.3));
+		float w = exp(-float(i) / 7.);
+		accum += w * exp(-strength * pow(abs(mag - prev), 2.3));
+		tw += w;
+		prev = mag;
+	}
+	return max(0., 5. * accum / tw - .7);
+}
+
+void main() {
+    // vec2 uv2 = 2. * FRAGCOORD.xy / vec2(512) - 1.;
+	vec2 uvs = v_uv;
+	
+    	//get coords and direction	
+	vec2 uv = uvs;		       
+	//mouse rotation
+	float a_xz = 0.9;
+	float a_yz = -.6;
+	float a_xy = 0.9 + u_time*0.08;	
+	
+	mat2 rot_xz = mat2(vec2(cos(a_xz),sin(a_xz)),vec2(-sin(a_xz),cos(a_xz)));	
+	mat2 rot_yz = mat2(vec2(cos(a_yz),sin(a_yz)),vec2(-sin(a_yz),cos(a_yz)));		
+	mat2 rot_xy = mat2(vec2(cos(a_xy),sin(a_xy)),vec2(-sin(a_xy),cos(a_xy)));
+	
+	float v2 =1.0;	
+	vec3 dir=vec3(uv*u_zoom,1.); 
+	vec3 from=vec3(0.0, 0.0,0.0);                               
+        // from.x -= 2.0*(mouse.x-0.5);
+        // from.y -= 2.0*(mouse.y-0.5);
+
+	vec3 forward = vec3(0.,0.,1.);   
+	from.x += u_transverse_speed*(1.0)*cos(0.01*u_time) + 0.001*u_time;
+	from.y += u_transverse_speed*(1.0)*sin(0.01*u_time) +0.001*u_time;
+	from.z += 0.003*u_time;	
+	
+	dir.xy*=rot_xy;
+	forward.xy *= rot_xy;
+	dir.xz*=rot_xz;
+	forward.xz *= rot_xz;	
+	dir.yz*= rot_yz;
+	forward.yz *= rot_yz;
+	
+	from.xy*=-1.0*rot_xy;
+	from.xz*=rot_xz;
+	from.yz*= rot_yz;
+	 
+	//zoom
+	float zooom = (u_time - 3311.) * u_speed;
+	from += forward* zooom;
+	float sampleShift = mod( zooom, u_step_size );
+	 
+	float zoffset = -sampleShift;
+	sampleShift /= u_step_size; // make from 0 to 1
+	
+	//volumetric rendering
+	float s=0.24;
+	float s3 = s + u_step_size/2.0;
+	vec3 v=vec3(0.);
+	float t3 = 0.0;	
+	
+	vec3 backCol2 = vec3(0.);
+	for (float r=0.0; r<u_visible_distance; r++) {
+		vec3 p2=from+(s+zoffset)*dir;// + vec3(0.,0.,zoffset);
+		vec3 p3=from+(s3+zoffset)*dir;// + vec3(0.,0.,zoffset);
+		
+		p2 = abs(vec3(tileScale)-mod(p2,vec3(tileScale*2.))); // tiling fold
+		p3 = abs(vec3(tileScale)-mod(p3,vec3(tileScale*2.))); // tiling fold		
+		// #ifdef cloud
+		t3 = field(p3);
+		
+		float pa,a=pa=0.;
+		for (int i=0; i<u_iterations; i++) {
+            if (u_dark_stars) {
+                // another interesting way to reduce noise
+			    p2 = abs(p2)/max(dot(p2,p2),0.005)-u_magic;
+            } else {
+                // the magic formula
+			    p2 = abs(p2)/dot(p2,p2)-u_magic;
+            }
+
+			float D = abs(length(p2)-pa); // absolute sum of average change
+			a += i > 7 ? min( 12., D) : D;
+			pa=length(p2);
+		}
+		
+		
+		//float dm=max(0.,darkmatter-a*a*.001); //dark matter
+		a*=a*a; // add contrast
+		//if (r>3) fade*=1.-dm; // dark matter, don't render near
+		// brightens stuff up a bit
+		float s1 = s+zoffset;
+		// need closed form expression for this, now that we shift samples
+		float fade = pow(u_dist_fading,max(0.,float(r)-sampleShift));		
+		//t3 += fade;		
+		v+=fade;
+	       	//backCol2 -= fade;
+
+		// fade out samples as they approach the camera
+		if( r == 0.0 )
+			fade *= (1. - (sampleShift));
+		// fade in samples as they approach from the distance
+		if( r == u_visible_distance-1.0 )
+			fade *= sampleShift;
+		v+=vec3(s1,s1*s1,s1*s1*s1*s1)*a*u_brightness/1000.*fade; // coloring based on distance
+		
+		backCol2 += mix(.4, 1., v2) * vec3(1.8 * t3 * t3 * t3, 1.4 * t3 * t3, t3) * fade;
+
+		
+		s+=u_step_size;
+		s3 += u_step_size;		
+	}
+		       
+	v = mix(vec3(length(v)),v,u_saturation); //color adjust	
+
+	vec4 forCol2 = vec4(v*.01,1.);
+	backCol2 *= u_cloud;
+    backCol2.rgb *= u_cloud_color.rgb;
+
+	// backCol2.b *= 1.8;
+	// backCol2.r *= 0.05;	
+	// backCol2.b = 0.5*mix(backCol2.g, backCol2.b, 0.8);
+	// backCol2.g = 0.0;
+	// backCol2.bg = mix(backCol2.gb, backCol2.bg, 0.5*(cos(u_time*0.01) + 1.0));	
+	
+	gl_FragColor = forCol2 + vec4(backCol2, 1.0);
+}

--- a/src/patterns/shaders/gentleRings.frag
+++ b/src/patterns/shaders/gentleRings.frag
@@ -1,0 +1,28 @@
+// From https://www.shadertoy.com/view/3dlfWH, credit to https://www.shadertoy.com/user/darknoon
+
+#include <conjurer_common>
+
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+varying vec2 v_uv;
+uniform float u_time;
+
+uniform Palette u_palette;
+
+
+void main() {
+    vec2 uv = v_uv;
+    
+    float r = length(uv);
+    float a = atan(uv.y, uv.x);
+    
+    float ring = 1.5 + 0.8 * sin(PI * 0.25 * u_time);
+    
+    float kr = 0.5 - 0.5 * cos(7. * PI * r); 
+    vec3 kq = 0.5 - 0.5 * sin(ring*vec3(30., 29.3, 28.6) * r - 6.0 * u_time + PI * vec3(-0.05, 0.5, 1.0));
+    vec3 c = kr * (0.1 + kq * (1. - 0.5* palette(a / PI, u_palette))) * (0.5 + 0.5 * sin(11.*a + 22.5*r));
+
+    gl_FragColor = vec4(mix(vec3(0.0, 0.0, 0.2), c, 0.85), 1.0);
+}

--- a/src/patterns/shaders/lightwaves.frag
+++ b/src/patterns/shaders/lightwaves.frag
@@ -9,6 +9,7 @@ uniform float u_time;
 
 uniform Palette u_palette;
 uniform float u_timeFactor;
+uniform float u_timeOffset;
 uniform float u_intensity;
 uniform float u_period;
 
@@ -18,13 +19,14 @@ void main() {
     float t = mix(0.01, 2.0, u_timeFactor);
     float p = mix(0.5, 3.0, u_period);
     vec2 uv = v_uv * p;
+    float time = u_time + u_timeOffset;
     for (float i = 0.0; i < 2.0; i ++) {
         uv = uv + i;
-        uv *= cos(length(uv) - i + u_time * t) + sin(uv.y);
-        uv -= sin(uv + i - u_time * (t + 0.1)) - cos(uv.y);
+        uv *= cos(length(uv) - i + time * t) + sin(uv.y);
+        uv -= sin(uv + i - time * (t + 0.1)) - cos(uv.y);
         float d = length(uv);
-        vec3 col = palette(length(uv) + u_time, u_palette);
-        d = cos(d * 2. + u_time * t) * .6;
+        vec3 col = palette(length(uv) + time, u_palette);
+        d = cos(d * 2. + time * t) * .6;
         d = pow(b / d, 1.01);
         finalColor += col * d;
     }


### PR DESCRIPTION
- Adds two new patterns, both pilfered shamelessly from the internet
- Introduces support for manually entering palette colors (this is tedious but can be helpful, especially when randomly generating palettes in the playground which I then want to copy over to the main editor)
- Adds a time-offset parameter to the light waves pattern. Defaults to zero, non-breaking change.
- Fixes z-index issue with the pattern effect menu
- Fixes bug in the color tint effect
- Undid the pattern/effect block header color change; I did this before I found out my chakra UI theme setting was `light` instead of `dark`