### PR TITLE
Rendering pipeline bug fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ Use webpack analyzer to analyze the bundle. Will launch three tabs in your brows
 
 You are good to go - when you change things with the controller, you should see the playground page update.
 
+### Performance issues / memory leaks
+
+This is a big React app, hastily designed, that's doing a lot of expensive CPU/GPU things, so it has been difficult to keep it running smoothly. Here are some random thoughts associated with performance:
+
+- You may encounter some memory leaks related to the hot module reloading/fast refresh when running the app locally. Just reloading or even hard reloading the tab in firefox doesn't free all of the used memory in my experience, so for the best results, if you have been changing code and the app has been hot reloading, you should periodically close the tab and open a new one.
+- Memory leaks are apparently much easier to accomplish in React than I realized: https://schiener.io/2024-03-03/react-closures
+- Careful with setTimeout chains/setInterval. Make sure there is a way to clean them up on hot reloads. useEffect is a good way to do this.
+- If the app slows down a bunch, use the browser profiler to identify where it's spending time. If it's spending time in the garbage collector/cycle collector, it's likely a memory leak issue. At the time of writing, running locally with devtools open the app should use about 1GB of memory.
+
 ## Todos
 
 To dos are captured in the [wiki](https://github.com/SotSF/conjurer/wiki), and occasionally are captured as issues.

--- a/src/components/Canvas/CanopyView.tsx
+++ b/src/components/Canvas/CanopyView.tsx
@@ -21,6 +21,22 @@ type CanopyGeometry = {
   normal: number[];
 };
 
+type CanopyProps = { renderTarget: WebGLRenderTarget };
+
+export const Canopy = function Canopy({ renderTarget }: CanopyProps) {
+  const [canopyGeometry, setCanopyGeometry] = useState<CanopyGeometry>();
+  useEffect(() => {
+    // Lazy load the canopy geometry
+    import("@/src/data/canopyGeometry.json").then((data) =>
+      setCanopyGeometry(data)
+    );
+  }, []);
+  if (!canopyGeometry) return null;
+  return (
+    <CanopyView renderTarget={renderTarget} canopyGeometry={canopyGeometry} />
+  );
+};
+
 type CanopyViewProps = {
   renderTarget: WebGLRenderTarget;
   canopyGeometry: CanopyGeometry;
@@ -101,21 +117,5 @@ const CanopyView = function CanopyView({
         />
       </points>
     </scene>
-  );
-};
-
-type CanopyProps = { renderTarget: WebGLRenderTarget };
-
-// Lazy load the canopy geometry
-export const Canopy = function Canopy({ renderTarget }: CanopyProps) {
-  const [canopyGeometry, setCanopyGeometry] = useState<CanopyGeometry>();
-  useEffect(() => {
-    import("@/src/data/canopyGeometry.json").then((data) =>
-      setCanopyGeometry(data)
-    );
-  }, []);
-  if (!canopyGeometry) return null;
-  return (
-    <CanopyView renderTarget={renderTarget} canopyGeometry={canopyGeometry} />
   );
 };

--- a/src/components/Canvas/DisplayCanvas.tsx
+++ b/src/components/Canvas/DisplayCanvas.tsx
@@ -6,9 +6,9 @@ import { RenderPipeline } from "@/src/components/RenderPipeline/RenderPipeline";
 import { CanopySpaceView } from "@/src/components/Canvas/CanopySpaceView";
 import { CameraControls } from "@/src/components/CameraControls";
 import { RenderOnTimeChange } from "@/src/components/RenderOnTimeChange";
-import { WebGLRenderTarget } from "three";
-import { lazy, useState } from "react";
+import { lazy } from "react";
 import { CartesianSpaceView } from "@/src/components/Canvas/CartesianSpaceView";
+import { useRenderTarget } from "@/src/hooks/renderTarget";
 
 const Perf = lazy(() =>
   import("r3f-perf").then((module) => ({ default: module.Perf }))
@@ -22,16 +22,14 @@ export const DisplayCanvas = observer(function DisplayCanvas() {
   const { uiStore, experienceName } = useStore();
   const { displayMode, showingPerformance } = uiStore;
 
-  const [renderTarget, setRenderTarget] = useState<WebGLRenderTarget | null>(
-    null
-  );
+  const renderTarget = useRenderTarget();
 
   return (
     <Canvas key={experienceName} frameloop={DEBUG ? "demand" : "always"}>
       {DEBUG && <RenderOnTimeChange />}
       {showingPerformance && <Perf />}
       <CameraControls />
-      <RenderPipeline setRenderTarget={setRenderTarget} />
+      <RenderPipeline renderTargetZ={renderTarget} />
       {renderTarget && (
         <>
           {displayMode === "canopy" && <Canopy renderTarget={renderTarget} />}

--- a/src/components/RenderPipeline/BlockStackNode.tsx
+++ b/src/components/RenderPipeline/BlockStackNode.tsx
@@ -63,7 +63,8 @@ export const BlockStackNode = observer(function BlockStackNode({
       />
       {parentBlock?.effectBlocks.map((effect, i) => {
         const isEven = i % 2 === 0;
-        const swap = evenNumberOfEffects ? isEven : !isEven;
+        // we want XNOR logical operation here, equivalent to strict equal for booleans
+        const swap = evenNumberOfEffects === isEven;
         return (
           <BlockNode
             key={effect.id}

--- a/src/components/RenderPipeline/RenderPipeline.tsx
+++ b/src/components/RenderPipeline/RenderPipeline.tsx
@@ -3,16 +3,15 @@ import { useStore } from "@/src/types/StoreContext";
 import { MergeNode } from "@/src/components/RenderPipeline/MergeNode";
 import { useRenderTarget } from "@/src/hooks/renderTarget";
 import { observer } from "mobx-react-lite";
-import { useEffect } from "react";
 import { WebGLRenderTarget } from "three";
 
 type Props = {
-  setRenderTarget: (renderTarget: WebGLRenderTarget) => void;
+  renderTargetZ: WebGLRenderTarget;
 };
 
 // TODO: generalize approach here for more than two layers
 export const RenderPipeline = observer(function RenderPipeline({
-  setRenderTarget,
+  renderTargetZ,
 }: Props) {
   const store = useStore();
 
@@ -20,30 +19,56 @@ export const RenderPipeline = observer(function RenderPipeline({
   const renderTargetB = useRenderTarget();
   const renderTargetC = useRenderTarget();
   const renderTargetD = useRenderTarget();
-  const renderTargetZ = useRenderTarget();
 
   const activeLayers = store.layers.filter(
     (layer) => layer.visible && !!layer.currentBlock
   );
 
-  useEffect(() => {
-    setRenderTarget(activeLayers.length === 2 ? renderTargetZ : renderTargetB);
-  }, [setRenderTarget, activeLayers.length, renderTargetB, renderTargetZ]);
+  /*
+  Because this can all get pretty confusing and it's a custom rendering pipeline, here are the broad
+  strokes of what's happening.
 
+  - activeLayers is an array of Layer objects that are visible and have a currentBlock
+  - depending on the number of active layers, we render in a different way
+  - however in all cases, the final output is renderTargetZ
+  - if there's only one active layer, we use renderTargetA as the input and renderTargetZ as the
+    output
+  - BlockStackNode is representative of the parent pattern block with optional effect blocks
+  - BlockStackNode will use (in the one active layer case) renderTargetA and renderTargetZ, and will
+    ping pong between them, always outputting to renderTargetZ
+  - if there are two active layers, each layer uses two render targets (A/B and C/D) and ping pongs
+    between them as before
+  - in the two active layer case, MergeNode takes the two layers' output render targets (B/D) and
+    merges them together into renderTargetZ
+  - the parameters (uniforms) are computed every frame using the useFrame hook with a priority
+    appropriate to the pattern/effect order
+
+  That is a pretty terrible explanation. I'll improve it soon/never.
+  */
   return (
     <>
-      {activeLayers.map((layer, index) => (
+      {activeLayers.length === 1 ? (
         <LayerNode
-          key={layer.id}
-          priority={index}
-          layer={layer}
-          renderTargetIn={index === 0 ? renderTargetA : renderTargetC}
-          renderTargetOut={index === 0 ? renderTargetB : renderTargetD}
+          key={activeLayers[0].id}
+          priority={0}
+          layer={activeLayers[0]}
+          renderTargetIn={renderTargetA}
+          renderTargetOut={renderTargetZ}
         />
-      ))}
+      ) : (
+        activeLayers.map((layer, index) => (
+          <LayerNode
+            key={layer.id}
+            priority={index}
+            layer={layer}
+            renderTargetIn={index === 0 ? renderTargetA : renderTargetC}
+            renderTargetOut={index === 0 ? renderTargetB : renderTargetD}
+          />
+        ))
+      )}
       {activeLayers.length === 2 && (
         <MergeNode
-          priority={10000}
+          priority={1000}
           renderTargetIn1={renderTargetB}
           opacity1={activeLayers[0].opacityParameter}
           renderTargetIn2={renderTargetD}


### PR DESCRIPTION
This has been bothering me forever. At certain moments in experiences under certain conditions, there would be this telltale lurch/jarring "off" frame. Finally founds the fix. Now we will always render to the same final render target ("renderTargetZ"). Before, when you would go between one and two active layers, the final output render target would need to be switched, which we were doing with an useEffect. Because the effect runs afterwards, it was in practice _sometimes_ too low and resulted in the "off" frame. Phewww