### PR TITLE
Try to find and launch the built ConjurerBridge application

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "src/scripts/try-start-unity-bridge.sh; next dev",
+    "dev": "next dev",
+    "prod": "src/scripts/try-start-unity-bridge.sh; next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "src/scripts/try-start-unity-bridge.sh; next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/src/scripts/try-start-unity-bridge.sh
+++ b/src/scripts/try-start-unity-bridge.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Try to open the Unity bridge when on MacOs
+if [[ "$OSTYPE" = "darwin"* ]]; then
+    # Define the application name pattern (e.g., MyApp_v*.app)
+    APP_NAME_PATTERN="ConjurerBridge_v*.app"
+
+    # Look for all applications matching the pattern in /Applications
+    APP_PATHS=($(find /Applications -maxdepth 1 -name "$APP_NAME_PATTERN"))
+
+    # Check if any application was found
+    if [[ ${#APP_PATHS[@]} -eq 0 ]]; then
+        echo "No Unity bridge application found matching the pattern $APP_NAME_PATTERN in /Applications."
+    else
+        # Extract version numbers from the app names and sort them to find the latest
+        LATEST_APP=""
+        LATEST_VERSION=""
+
+        for APP_PATH in "${APP_PATHS[@]}"; do
+            echo "Found Unity bridge application: $APP_PATH"
+            # Extract version number from the app name using regex
+            VERSION=$(echo "$APP_PATH" | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
+            if [[ -z "$VERSION" ]]; then
+                continue
+            fi
+
+            # Compare versions and keep the latest
+            if [[ -z "$LATEST_VERSION" || "$VERSION" > "$LATEST_VERSION" ]]; then
+                LATEST_VERSION="$VERSION"
+                LATEST_APP="$APP_PATH"
+            fi
+        done
+    fi
+    # Check if we found the latest app
+    if [[ -z "$LATEST_APP" ]]; then
+        echo "No valid versioned application found."
+    else
+        # Launch the latest application
+        echo "Latest = $LATEST_VERSION"
+        echo "Launching $LATEST_APP"
+        open "$LATEST_APP"
+    fi
+fi


### PR DESCRIPTION
This changes `yarn dev` to search for a built ConjurerBridge application in `/Applications`, then launches the latest version if it finds one. This should make the startup process for the MC persona simpler.

Built ConjurerBridge binaries can be [found eg here](https://github.com/SotSF/canopy-unity/releases/tag/conjurer_bridge_osx_v0.0.4)