### PR TITLE
refactor: put createdAt and updatedAt into a reusable block

### DIFF
--- a/migrations/0003_empty_valeria_richards.sql
+++ b/migrations/0003_empty_valeria_richards.sql
@@ -1,0 +1,46 @@
+CREATE TABLE `experiences_tmp` (
+        `id` integer PRIMARY KEY NOT NULL,
+        `name` text NOT NULL,
+        `song_id` integer NOT NULL,
+        `status` text DEFAULT 'inprogress' NOT NULL,
+        `data` text NOT NULL,
+        `version` integer DEFAULT 0 NOT NULL,
+        `created_at` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+        `updated_at` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+        `user_id` integer
+);
+--> statement-breakpoint
+INSERT INTO `experiences_tmp` (id, name, song_id, status, data, version, created_at, updated_at, user_id)
+  SELECT e.id, e.name, e.song_id, e.status, e.data, e.version, e.created_at, e.updated_at, NULL
+    FROM experiences e;
+--> statement-breakpoint
+UPDATE experiences_tmp SET user_id = (
+  SELECT user_id
+    FROM users_to_experiences
+    WHERE experiences_tmp.id = users_to_experiences.experience_id
+    LIMIT 1
+);
+--> statement-breakpoint
+ALTER TABLE `experiences` RENAME TO `experiences_old`;
+--> statement-breakpoint
+CREATE TABLE `experiences` (
+        `id` integer PRIMARY KEY NOT NULL,
+        `name` text NOT NULL,
+        `song_id` integer NOT NULL,
+        `status` text DEFAULT 'inprogress' NOT NULL,
+        `data` text NOT NULL,
+        `version` integer DEFAULT 0 NOT NULL,
+        `created_at` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+        `updated_at` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+        `user_id` integer NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO experiences (id, name, song_id, status, data, version, created_at, updated_at, user_id)
+  SELECT id, name, song_id, status, data, version, created_at, updated_at, user_id
+    FROM experiences_tmp;
+--> statement-breakpoint
+DROP TABLE experiences_tmp;
+--> statement-breakpoint
+DROP TABLE experiences_old;
+--> statement-breakpoint
+DROP TABLE users_to_experiences;

--- a/migrations/meta/0003_snapshot.json
+++ b/migrations/meta/0003_snapshot.json
@@ -1,0 +1,400 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a4868717-d0eb-4812-9fc2-d1762a2ac2be",
+  "prevId": "365e6651-acc8-4433-9258-368dfcde3d15",
+  "tables": {
+    "experiences": {
+      "name": "experiences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inprogress'"
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "experiences_name_unique": {
+          "name": "experiences_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "status_index": {
+          "name": "status_index",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "orderedExperienceIds": {
+          "name": "orderedExperienceIds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "user_id_index": {
+          "name": "user_id_index",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "playlists_user_id_users_id_fk": {
+          "name": "playlists_user_id_users_id_fk",
+          "tableFrom": "playlists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "songs": {
+      "name": "songs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "song_name_artist_index": {
+          "name": "song_name_artist_index",
+          "columns": [
+            "artist",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users_to_experiences": {
+      "name": "users_to_experiences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "experience_id": {
+          "name": "experience_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "user_experience_index": {
+          "name": "user_experience_index",
+          "columns": [
+            "user_id",
+            "experience_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "users_to_experiences_user_id_users_id_fk": {
+          "name": "users_to_experiences_user_id_users_id_fk",
+          "tableFrom": "users_to_experiences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_to_experiences_experience_id_experiences_id_fk": {
+          "name": "users_to_experiences_experience_id_experiences_id_fk",
+          "tableFrom": "users_to_experiences",
+          "tableTo": "experiences",
+          "columnsFrom": [
+            "experience_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1730598821462,
       "tag": "0002_sweet_maria_hill",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1731487566800,
+      "tag": "0003_empty_valeria_richards",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "eslint": "^8.56.0",
     "eslint-config-next": "^14.2.16",
     "eslint-plugin-mobx": "^0.0.9",
+    "prettier": "^3.3.3",
     "r3f-perf": "^7.1.2",
     "typescript": "^5.2.2"
   }

--- a/src/components/ExperiencesTable/ExperiencesTable.tsx
+++ b/src/components/ExperiencesTable/ExperiencesTable.tsx
@@ -17,7 +17,7 @@ import { FaTrashAlt } from "react-icons/fa";
 import { Experience } from "@/src/types/Experience";
 
 type ExperiencesTableProps = {
-  experiencesAndUsers: { user: { username: string }; experience: Experience }[];
+  experiences: Experience[];
   omitIds?: number[];
   onClickExperience?: (experience: Experience) => void;
   selectable?: boolean;
@@ -26,7 +26,7 @@ type ExperiencesTableProps = {
 };
 
 export const ExperiencesTable = observer(function ExperiencesTable({
-  experiencesAndUsers,
+  experiences,
   onClickExperience,
   omitIds,
   selectable,
@@ -40,7 +40,7 @@ export const ExperiencesTable = observer(function ExperiencesTable({
     setSelectedExperienceIds?.(
       selectedExperienceIds?.includes(id)
         ? selectedExperienceIds.filter((selectedId) => selectedId !== id)
-        : [...(selectedExperienceIds ?? []), id]
+        : [...(selectedExperienceIds ?? []), id],
     );
   };
 
@@ -57,15 +57,15 @@ export const ExperiencesTable = observer(function ExperiencesTable({
           </Tr>
         </Thead>
         <Tbody>
-          {experiencesAndUsers
-            .filter(({ experience }) => !omitIds?.includes(experience.id!))
-            .map(({ user, experience }) => (
+          {experiences
+            .filter((experience) => !omitIds?.includes(experience.id!))
+            .map((experience) => (
               <Tr key={experience.id}>
                 {selectable && (
                   <Td>
                     <Checkbox
                       isChecked={selectedExperienceIds?.includes(
-                        experience.id!
+                        experience.id!,
                       )}
                       onChange={() =>
                         toggleExperienceIdSelection(experience.id!)
@@ -87,12 +87,12 @@ export const ExperiencesTable = observer(function ExperiencesTable({
                     {experience.name}
                   </Button>
                 </Td>
-                <Td>{user.username}</Td>
+                <Td>{experience.user.username}</Td>
                 <Td>
                   {experience.song?.artist} - {experience.song?.name}
                 </Td>
                 <Td>
-                  {user.username === username && (
+                  {experience.user.username === username && (
                     <IconButton
                       variant="ghost"
                       size="sm"
@@ -103,7 +103,7 @@ export const ExperiencesTable = observer(function ExperiencesTable({
                       onClick={action(() => {
                         if (
                           !confirm(
-                            "Are you sure you want to delete this experience? This will permanently cast the experience into the fires of Mount Doom. (jk doesn't work yet)"
+                            "Are you sure you want to delete this experience? This will permanently cast the experience into the fires of Mount Doom. (jk doesn't work yet)",
                           )
                         )
                           return;

--- a/src/components/Menu/OpenExperienceModal.tsx
+++ b/src/components/Menu/OpenExperienceModal.tsx
@@ -16,7 +16,7 @@ import { useStore } from "@/src/types/StoreContext";
 import { action } from "mobx";
 import { useState } from "react";
 import { ExperiencesTable } from "@/src/components/ExperiencesTable/ExperiencesTable";
-import { useExperiencesAndUsers } from "@/src/hooks/experiencesAndUsers";
+import { useExperiences } from "@/src/hooks/experiencesAndUsers";
 
 export const OpenExperienceModal = observer(function OpenExperienceModal() {
   const store = useStore();
@@ -25,11 +25,10 @@ export const OpenExperienceModal = observer(function OpenExperienceModal() {
   const [viewingAllExperiences, setViewingAllExperiences] = useState(false);
   const [isLoadingNewExperience, setIsLoadingNewExperience] = useState(false);
 
-  const { isPending, isError, isRefetching, experiencesAndUsers } =
-    useExperiencesAndUsers({
-      username: viewingAllExperiences ? undefined : username,
-      enabled: uiStore.showingOpenExperienceModal,
-    });
+  const { isPending, isError, isRefetching, experiences } = useExperiences({
+    username: viewingAllExperiences ? undefined : username,
+    enabled: uiStore.showingOpenExperienceModal,
+  });
 
   const onClose = action(() => (uiStore.showingOpenExperienceModal = false));
 
@@ -52,7 +51,7 @@ export const OpenExperienceModal = observer(function OpenExperienceModal() {
         </ModalHeader>
         <ModalCloseButton />
         <ModalBody>
-          {!isPending && experiencesAndUsers.length === 0 && (
+          {!isPending && experiences.length === 0 && (
             <Text color="gray.400">
               {username} has no saved experiences yet!
             </Text>
@@ -66,7 +65,7 @@ export const OpenExperienceModal = observer(function OpenExperienceModal() {
           </Switch>
           {!isPending && (
             <ExperiencesTable
-              experiencesAndUsers={experiencesAndUsers}
+              experiences={experiences}
               onClickExperience={action(async (experience) => {
                 setIsLoadingNewExperience(true);
                 await experienceStore.load(experience.name);

--- a/src/components/PlaylistEditor/AddExperienceModal.tsx
+++ b/src/components/PlaylistEditor/AddExperienceModal.tsx
@@ -18,7 +18,7 @@ import { ExperiencesTable } from "@/src/components/ExperiencesTable/ExperiencesT
 import { useState } from "react";
 import { Playlist } from "@/src/types/Playlist";
 import { useSavePlaylist } from "@/src/hooks/playlist";
-import { useExperiencesAndUsers } from "@/src/hooks/experiencesAndUsers";
+import { useExperiences } from "@/src/hooks/experiencesAndUsers";
 
 export const AddExperienceModal = observer(function AddExperienceModal({
   playlist,
@@ -30,10 +30,10 @@ export const AddExperienceModal = observer(function AddExperienceModal({
 
   const [viewingAllExperiences, setViewingAllExperiences] = useState(false);
   const [selectedExperienceIds, setSelectedExperienceIds] = useState<number[]>(
-    []
+    [],
   );
 
-  const { isPending, isError, experiencesAndUsers } = useExperiencesAndUsers({
+  const { isPending, isError, experiences } = useExperiences({
     username: viewingAllExperiences ? undefined : username,
     enabled: uiStore.showingPlaylistAddExperienceModal,
   });
@@ -60,7 +60,7 @@ export const AddExperienceModal = observer(function AddExperienceModal({
           Add experience to playlist {isPending && <Spinner />}
         </ModalHeader>
         <ModalBody>
-          {!isPending && experiencesAndUsers.length === 0 && (
+          {!isPending && experiences.length === 0 && (
             <Text color="gray.400">
               {username} has no saved experiences yet!
             </Text>
@@ -74,7 +74,7 @@ export const AddExperienceModal = observer(function AddExperienceModal({
           </Switch>
           {!isPending && (
             <ExperiencesTable
-              experiencesAndUsers={experiencesAndUsers}
+              experiences={experiences}
               omitIds={playlist.orderedExperienceIds}
               selectable
               selectedExperienceIds={selectedExperienceIds}

--- a/src/components/PlaylistEditor/PlaylistEditor.tsx
+++ b/src/components/PlaylistEditor/PlaylistEditor.tsx
@@ -43,7 +43,7 @@ export const PlaylistEditor = observer(function PlaylistEditor() {
     {
       enabled: selectedPlaylist !== null,
       staleTime: 1000 * 60 * 10,
-    }
+    },
   );
 
   useEffect(() => {
@@ -54,16 +54,16 @@ export const PlaylistEditor = observer(function PlaylistEditor() {
   }, [playlistStore, data?.playlist]);
 
   useEffect(() => {
-    if (!data?.experiencesAndUsers.length || store.experienceName) return;
+    if (!data?.playlistExperiences.length || store.experienceName) return;
     // once experiences are fetched, load the first experience in the playlist
-    store.experienceStore.load(data.experiencesAndUsers[0].experience.name);
-  }, [store.experienceName, store.experienceStore, data?.experiencesAndUsers]);
+    store.experienceStore.load(data.playlistExperiences[0].name);
+  }, [store.experienceName, store.experienceStore, data?.playlistExperiences]);
 
   const router = useRouter();
 
   if (isPending || isError) return null;
 
-  const { playlist, experiencesAndUsers } = data;
+  const { playlist, playlistExperiences } = data;
 
   return (
     <VStack m={6} justify="start" alignItems="start">
@@ -78,7 +78,7 @@ export const PlaylistEditor = observer(function PlaylistEditor() {
             onClick={action(
               () =>
                 (playlistStore.shufflingPlaylist =
-                  !playlistStore.shufflingPlaylist)
+                  !playlistStore.shufflingPlaylist),
             )}
             leftIcon={<BiShuffle size={14} />}
             bgColor={playlistStore.shufflingPlaylist ? "orange.600" : undefined}
@@ -95,7 +95,8 @@ export const PlaylistEditor = observer(function PlaylistEditor() {
           <Button
             onClick={action(
               () =>
-                (playlistStore.loopingPlaylist = !playlistStore.loopingPlaylist)
+                (playlistStore.loopingPlaylist =
+                  !playlistStore.loopingPlaylist),
             )}
             leftIcon={<ImLoop size={14} />}
             bgColor={playlistStore.loopingPlaylist ? "orange.600" : undefined}
@@ -134,7 +135,7 @@ export const PlaylistEditor = observer(function PlaylistEditor() {
       )}
       <HStack justify="start" align="center" spacing={4}>
         <Text fontSize="md" color="gray.400">
-          {playlist.user.username} • {experiencesAndUsers.length} experiences
+          {playlist.user.username} • {playlistExperiences.length} experiences
         </Text>
       </HStack>
 
@@ -150,7 +151,7 @@ export const PlaylistEditor = observer(function PlaylistEditor() {
             </Tr>
           </Thead>
           <Tbody>
-            {experiencesAndUsers.length === 0 ? (
+            {playlistExperiences.length === 0 ? (
               <>
                 <Tr>
                   <Td>-</Td>
@@ -163,14 +164,14 @@ export const PlaylistEditor = observer(function PlaylistEditor() {
                 </Tr>
               </>
             ) : (
-              experiencesAndUsers.map(({ experience, user }, index) => (
+              playlistExperiences.map((experience, index) => (
                 <Tr key={experience.id}>
                   <PlaylistItem
                     playlist={playlist}
                     experience={experience}
-                    user={user}
+                    user={experience.user}
                     index={index}
-                    playlistLength={experiencesAndUsers.length}
+                    playlistLength={playlistExperiences.length}
                     editable={isEditable}
                   />
                 </Tr>
@@ -188,7 +189,7 @@ export const PlaylistEditor = observer(function PlaylistEditor() {
               size="sm"
               leftIcon={<MdOutlinePlaylistAdd size={20} />}
               onClick={action(
-                () => (uiStore.showingPlaylistAddExperienceModal = true)
+                () => (uiStore.showingPlaylistAddExperienceModal = true),
               )}
             >
               Add experience

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -26,7 +26,7 @@ export const users = sqliteTable("users", {
 });
 
 export const usersRelations = relations(users, ({ many }) => ({
-  usersToExperiences: many(usersToExperiences),
+  experiences: many(experiences),
 }));
 
 export type InsertUser = typeof users.$inferInsert;
@@ -68,6 +68,7 @@ export const experiences = sqliteTable(
       .default("inprogress"),
     data: text({ mode: "json" }).notNull(),
     version: integer("version").notNull().default(0),
+    userId: integer("user_id").notNull(),
 
     ...timestamps,
   },
@@ -76,9 +77,9 @@ export const experiences = sqliteTable(
   }),
 );
 
-export const experiencesRelations = relations(experiences, ({ one, many }) => ({
+export const experiencesRelations = relations(experiences, ({ one }) => ({
   song: one(songs, { fields: [experiences.songId], references: [songs.id] }),
-  usersToExperiences: many(usersToExperiences),
+  user: one(users, { fields: [experiences.userId], references: [users.id] }),
 }));
 
 export type InsertExperience = typeof experiences.$inferInsert;
@@ -104,23 +105,6 @@ export const usersToExperiences = sqliteTable(
     ),
   }),
 );
-
-export const usersToExperiencesRelations = relations(
-  usersToExperiences,
-  ({ one }) => ({
-    user: one(users, {
-      fields: [usersToExperiences.userId],
-      references: [users.id],
-    }),
-    experience: one(experiences, {
-      fields: [usersToExperiences.experienceId],
-      references: [experiences.id],
-    }),
-  }),
-);
-
-export type InsertAuthorship = typeof usersToExperiences.$inferInsert;
-export type SelectAuthorship = typeof usersToExperiences.$inferSelect;
 
 export const playlists = sqliteTable(
   "playlists",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -44,9 +44,9 @@ export const songs = sqliteTable(
   (table) => ({
     songNameArtistIndex: uniqueIndex("song_name_artist_index").on(
       table.artist,
-      table.name
+      table.name,
     ),
-  })
+  }),
 );
 
 export const songsRelations = relations(songs, ({ many }) => ({
@@ -73,7 +73,7 @@ export const experiences = sqliteTable(
   },
   (table) => ({
     status_index: index("status_index").on(table.status),
-  })
+  }),
 );
 
 export const experiencesRelations = relations(experiences, ({ one, many }) => ({
@@ -100,9 +100,9 @@ export const usersToExperiences = sqliteTable(
   (table) => ({
     userExperienceIndex: uniqueIndex("user_experience_index").on(
       table.userId,
-      table.experienceId
+      table.experienceId,
     ),
-  })
+  }),
 );
 
 export const usersToExperiencesRelations = relations(
@@ -116,7 +116,7 @@ export const usersToExperiencesRelations = relations(
       fields: [usersToExperiences.experienceId],
       references: [experiences.id],
     }),
-  })
+  }),
 );
 
 export type InsertAuthorship = typeof usersToExperiences.$inferInsert;
@@ -143,7 +143,7 @@ export const playlists = sqliteTable(
   },
   (table) => ({
     userIdIndex: index("user_id_index").on(table.userId),
-  })
+  }),
 );
 
 export const playlistsRelations = relations(playlists, ({ one }) => ({

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -8,11 +8,7 @@ import {
   uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 
-export const users = sqliteTable("users", {
-  id: integer("id").primaryKey(),
-  username: text("username").unique().notNull(),
-  isAdmin: integer("is_admin", { mode: "boolean" }).notNull().default(false),
-
+const timestamps = {
   createdAt: text("created_at")
     .default(sql`(CURRENT_TIMESTAMP)`)
     .notNull(),
@@ -20,6 +16,13 @@ export const users = sqliteTable("users", {
     .default(sql`(CURRENT_TIMESTAMP)`)
     .notNull()
     .$onUpdate(() => sql`(CURRENT_TIMESTAMP)`),
+};
+
+export const users = sqliteTable("users", {
+  id: integer("id").primaryKey(),
+  username: text("username").unique().notNull(),
+  isAdmin: integer("is_admin", { mode: "boolean" }).notNull().default(false),
+  ...timestamps,
 });
 
 export const usersRelations = relations(users, ({ many }) => ({
@@ -36,14 +39,7 @@ export const songs = sqliteTable(
     name: text("name").notNull(),
     artist: text("artist").notNull().default(""),
     filename: text("filename").notNull(),
-
-    createdAt: text("created_at")
-      .default(sql`(CURRENT_TIMESTAMP)`)
-      .notNull(),
-    updatedAt: text("updated_at")
-      .default(sql`(CURRENT_TIMESTAMP)`)
-      .notNull()
-      .$onUpdate(() => sql`(CURRENT_TIMESTAMP)`),
+    ...timestamps,
   },
   (table) => ({
     songNameArtistIndex: uniqueIndex("song_name_artist_index").on(
@@ -73,13 +69,7 @@ export const experiences = sqliteTable(
     data: text({ mode: "json" }).notNull(),
     version: integer("version").notNull().default(0),
 
-    createdAt: text("created_at")
-      .default(sql`(CURRENT_TIMESTAMP)`)
-      .notNull(),
-    updatedAt: text("updated_at")
-      .default(sql`(CURRENT_TIMESTAMP)`)
-      .notNull()
-      .$onUpdate(() => sql`(CURRENT_TIMESTAMP)`),
+    ...timestamps,
   },
   (table) => ({
     status_index: index("status_index").on(table.status),
@@ -105,13 +95,7 @@ export const usersToExperiences = sqliteTable(
       .notNull()
       .references(() => experiences.id, { onDelete: "cascade" }),
 
-    createdAt: text("created_at")
-      .default(sql`(CURRENT_TIMESTAMP)`)
-      .notNull(),
-    updatedAt: text("updated_at")
-      .default(sql`(CURRENT_TIMESTAMP)`)
-      .notNull()
-      .$onUpdate(() => sql`(CURRENT_TIMESTAMP)`),
+    ...timestamps,
   },
   (table) => ({
     userExperienceIndex: uniqueIndex("user_experience_index").on(
@@ -155,13 +139,7 @@ export const playlists = sqliteTable(
       .notNull()
       .default([]),
 
-    createdAt: text("created_at")
-      .default(sql`(CURRENT_TIMESTAMP)`)
-      .notNull(),
-    updatedAt: text("updated_at")
-      .default(sql`(CURRENT_TIMESTAMP)`)
-      .notNull()
-      .$onUpdate(() => sql`(CURRENT_TIMESTAMP)`),
+    ...timestamps,
   },
   (table) => ({
     userIdIndex: index("user_id_index").on(table.userId),

--- a/src/hooks/experience.ts
+++ b/src/hooks/experience.ts
@@ -62,7 +62,7 @@ export const useSaveExperience = () => {
     });
 
     utils.experience.listExperiencesForUser.invalidate();
-    utils.experience.listExperiencesAndUsers.invalidate();
+    utils.experience.listExperiences.invalidate();
   };
 
   return { saveExperience };

--- a/src/hooks/experiencesAndUsers.ts
+++ b/src/hooks/experiencesAndUsers.ts
@@ -1,7 +1,7 @@
 import { useStore } from "@/src/types/StoreContext";
 import { trpc } from "@/src/utils/trpc";
 
-export const useExperiencesAndUsers = ({
+export const useExperiences = ({
   username,
   enabled,
 }: {
@@ -15,25 +15,23 @@ export const useExperiencesAndUsers = ({
     isPending,
     isError,
     isRefetching,
-    data: experiencesAndUsers,
-  } = trpc.experience.listExperiencesAndUsers.useQuery(
+    data: experiences,
+  } = trpc.experience.listExperiences.useQuery(
     {
       username,
       usingLocalData,
     },
-    { enabled }
+    { enabled },
   );
 
-  const sortedExperiencesAndUsers = (experiencesAndUsers ?? []).sort((a, b) =>
-    `${a.user.username}${a.experience.name}`.localeCompare(
-      `${b.user.username}${b.experience.name}`
-    )
+  const sortedExperiences = (experiences ?? []).sort((a, b) =>
+    `${a.user.username}${a.name}`.localeCompare(`${b.user.username}${b.name}`),
   );
 
   return {
     isPending,
     isError,
     isRefetching,
-    experiencesAndUsers: sortedExperiencesAndUsers,
+    experiences: sortedExperiences,
   };
 };

--- a/src/scripts/tursoMigration.ts
+++ b/src/scripts/tursoMigration.ts
@@ -86,7 +86,7 @@ const songMap: Record<
 
 // Experience filename format: <user>-<experienceName>.json
 const extractPartsFromExperienceFilename = (
-  filename: string
+  filename: string,
 ): { user: string; experienceName: string } => {
   const parts = filename.split("-");
   return {
@@ -127,12 +127,12 @@ const migration = async () => {
   const experiences = await getExperiences();
 
   const users: string[] = Array.from(
-    new Set(experiences.map((experience) => experience.user))
+    new Set(experiences.map((experience) => experience.user)),
   );
   const songs: string[] = Array.from(
     new Set(
-      experiences.map((experience) => experience.audioStore.selectedAudioFile)
-    )
+      experiences.map((experience) => experience.audioStore.selectedAudioFile),
+    ),
   );
   for (const song of songs) {
     if (!songMap[song]) {
@@ -173,29 +173,19 @@ const migration = async () => {
     const data = { layers: experience.layers };
     const { experienceName: truncatedName } =
       extractPartsFromExperienceFilename(experience.name);
-    const [dbExperience] = await localDB
+    await localDB
       .insert(schema.experiences)
       .values([
         {
           name: truncatedName === "untitled" ? experience.name : truncatedName,
           songId: song.id,
           version: 1,
+          userId: user.id,
           data,
         },
       ])
-      .returning()
       .execute();
     console.log("created experience", experience.name);
-    await localDB
-      .insert(schema.usersToExperiences)
-      .values([
-        {
-          userId: user.id,
-          experienceId: dbExperience.id,
-        },
-      ])
-      .execute();
-    console.log("linked user to experience");
   }
 };
 

--- a/src/server/routers/experienceRouter.ts
+++ b/src/server/routers/experienceRouter.ts
@@ -25,47 +25,6 @@ export const experienceRouter = router({
           .all(),
     ),
 
-  // listExperiencesForUser: userProcedure.query(async ({ ctx }) => {
-  //   // Approach 1: uses db.select and only requires one query, but the types are nullable in the end for some reason
-  //   // return await ctx.db
-  //   //   .select({ id: experiences.id, name: experiences.name })
-  //   //   .from(usersToExperiences)
-  //   //   .leftJoin(users, eq(usersToExperiences.userId , users.id))
-  //   //   .leftJoin(
-  //   //     experiences,
-  //   //     eq(usersToExperiences.experienceId, experiences.id)
-  //   //   )
-  //   //   .where(eq(users.username, input.username))
-  //   //   .all();
-
-  //   // Approach 2: uses db.query and one query, but currently nested select filters are not supported. They will be supported in the future.
-  //   // return await ctx.db.query.usersToExperiences
-  //   //   .findMany({
-  //   //     columns: {},
-  //   //     with: {
-  //   //       user: {
-  //   //         columns: { username: true },
-  //   //         where: (users, { eq }) => eq(users.username, input.username),
-  //   //       },
-  //   //       experience: { columns: { id: true, name: true } },
-  //   //     },
-  //   //   })
-  //   //   .execute();
-
-  //   // Approach 3: uses db.query which is nice but requires 2 queries (the below one and the one in userProcedure)
-  //   return (
-  //     await ctx.db.query.usersToExperiences
-  //       .findMany({
-  //         where: eq(usersToExperiences.userId, ctx.user.id),
-  //         columns: {},
-  //         with: {
-  //           experience: { columns: { id: true, name: true } },
-  //         },
-  //       })
-  //       .execute()
-  //   ).map(({ experience }) => experience);
-  // }),
-
   listExperiences: databaseProcedure
     .input(
       z.object({

--- a/src/server/routers/experienceRouter.ts
+++ b/src/server/routers/experienceRouter.ts
@@ -12,17 +12,16 @@ export const experienceRouter = router({
         username: z.string(),
       }),
     )
-    .query(
-      async ({ ctx, input }) =>
-        await ctx.db
-          .select({
-            id: experiences.id,
-            name: experiences.name,
-          })
-          .from(experiences)
-          .leftJoin(users, eq(experiences.userId, users.id))
-          .where(eq(users.username, input.username))
-          .all(),
+    .query(({ ctx, input }) =>
+      ctx.db
+        .select({
+          id: experiences.id,
+          name: experiences.name,
+        })
+        .from(experiences)
+        .leftJoin(users, eq(experiences.userId, users.id))
+        .where(eq(users.username, input.username))
+        .all(),
     ),
 
   listExperiences: databaseProcedure
@@ -119,14 +118,14 @@ export const experienceRouter = router({
         usingLocalData: z.boolean(),
       }),
     )
-    .query(async ({ ctx, input }) => {
-      return await ctx.db.query.experiences
+    .query(({ ctx, input }) =>
+      ctx.db.query.experiences
         .findFirst({
           with: { user: true, song: true },
           where: eq(experiences.name, input.experienceName),
         })
-        .execute();
-    }),
+        .execute(),
+    ),
 
   getExperienceById: databaseProcedure
     .input(
@@ -135,12 +134,12 @@ export const experienceRouter = router({
         usingLocalData: z.boolean(),
       }),
     )
-    .query(async ({ ctx, input }) => {
-      return await ctx.db.query.experiences
+    .query(({ ctx, input }) =>
+      ctx.db.query.experiences
         .findFirst({
           with: { user: true, song: true },
           where: eq(experiences.id, input.experienceId),
         })
-        .execute();
-    }),
+        .execute(),
+    ),
 });

--- a/src/server/routers/experienceRouter.ts
+++ b/src/server/routers/experienceRouter.ts
@@ -1,90 +1,95 @@
 import { router, databaseProcedure, userProcedure } from "@/src/server/trpc";
 import { z } from "zod";
-import { experiences, users, usersToExperiences } from "@/src/db/schema";
+import { experiences, users } from "@/src/db/schema";
 import { eq } from "drizzle-orm";
 import { EXPERIENCE_STATUSES } from "@/src/types/Experience";
 import { TRPCError } from "@trpc/server";
 
 export const experienceRouter = router({
-  listExperiencesForUser: userProcedure.query(async ({ ctx }) => {
-    // Approach 1: uses db.select and only requires one query, but the types are nullable in the end for some reason
-    // return await ctx.db
-    //   .select({ id: experiences.id, name: experiences.name })
-    //   .from(usersToExperiences)
-    //   .leftJoin(users, eq(usersToExperiences.userId , users.id))
-    //   .leftJoin(
-    //     experiences,
-    //     eq(usersToExperiences.experienceId, experiences.id)
-    //   )
-    //   .where(eq(users.username, input.username))
-    //   .all();
+  listExperiencesForUser: databaseProcedure
+    .input(
+      z.object({
+        username: z.string(),
+      }),
+    )
+    .query(
+      async ({ ctx, input }) =>
+        await ctx.db
+          .select({
+            id: experiences.id,
+            name: experiences.name,
+          })
+          .from(experiences)
+          .leftJoin(users, eq(experiences.userId, users.id))
+          .where(eq(users.username, input.username))
+          .all(),
+    ),
 
-    // Approach 2: uses db.query and one query, but currently nested select filters are not supported. They will be supported in the future.
-    // return await ctx.db.query.usersToExperiences
-    //   .findMany({
-    //     columns: {},
-    //     with: {
-    //       user: {
-    //         columns: { username: true },
-    //         where: (users, { eq }) => eq(users.username, input.username),
-    //       },
-    //       experience: { columns: { id: true, name: true } },
-    //     },
-    //   })
-    //   .execute();
+  // listExperiencesForUser: userProcedure.query(async ({ ctx }) => {
+  //   // Approach 1: uses db.select and only requires one query, but the types are nullable in the end for some reason
+  //   // return await ctx.db
+  //   //   .select({ id: experiences.id, name: experiences.name })
+  //   //   .from(usersToExperiences)
+  //   //   .leftJoin(users, eq(usersToExperiences.userId , users.id))
+  //   //   .leftJoin(
+  //   //     experiences,
+  //   //     eq(usersToExperiences.experienceId, experiences.id)
+  //   //   )
+  //   //   .where(eq(users.username, input.username))
+  //   //   .all();
 
-    // Approach 3: uses db.query which is nice but requires 2 queries (the below one and the one in userProcedure)
-    return (
-      await ctx.db.query.usersToExperiences
-        .findMany({
-          where: eq(usersToExperiences.userId, ctx.user.id),
-          columns: {},
-          with: {
-            experience: { columns: { id: true, name: true } },
-          },
-        })
-        .execute()
-    ).map(({ experience }) => experience);
-  }),
+  //   // Approach 2: uses db.query and one query, but currently nested select filters are not supported. They will be supported in the future.
+  //   // return await ctx.db.query.usersToExperiences
+  //   //   .findMany({
+  //   //     columns: {},
+  //   //     with: {
+  //   //       user: {
+  //   //         columns: { username: true },
+  //   //         where: (users, { eq }) => eq(users.username, input.username),
+  //   //       },
+  //   //       experience: { columns: { id: true, name: true } },
+  //   //     },
+  //   //   })
+  //   //   .execute();
 
-  listExperiencesAndUsers: databaseProcedure
+  //   // Approach 3: uses db.query which is nice but requires 2 queries (the below one and the one in userProcedure)
+  //   return (
+  //     await ctx.db.query.usersToExperiences
+  //       .findMany({
+  //         where: eq(usersToExperiences.userId, ctx.user.id),
+  //         columns: {},
+  //         with: {
+  //           experience: { columns: { id: true, name: true } },
+  //         },
+  //       })
+  //       .execute()
+  //   ).map(({ experience }) => experience);
+  // }),
+
+  listExperiences: databaseProcedure
     .input(
       z.object({
         username: z.string().optional(),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
-      if (!input.username) {
-        return await ctx.db.query.usersToExperiences
-          .findMany({
-            columns: {},
-            with: {
-              user: { columns: { username: true } },
-              experience: {
-                columns: { id: true, name: true, status: true, version: true },
-                with: { song: true },
-              },
-            },
-          })
+      let whereClause = {};
+      if (input.username) {
+        const user = await ctx.db.query.users
+          .findFirst({ where: eq(users.username, input.username) })
           .execute();
+        if (!user) return [];
+        whereClause = { where: eq(experiences.userId, user.id) };
       }
 
-      const user = await ctx.db.query.users
-        .findFirst({ where: eq(users.username, input.username) })
-        .execute();
-      if (!user) return [];
-
-      return await ctx.db.query.usersToExperiences
+      return await ctx.db.query.experiences
         .findMany({
-          where: eq(usersToExperiences.userId, user.id),
-          columns: {},
+          columns: { id: true, name: true, status: true, version: true },
           with: {
-            user: { columns: { username: true } },
-            experience: {
-              columns: { id: true, name: true, status: true, version: true },
-              with: { song: { columns: { name: true, artist: true } } },
-            },
+            user: { columns: { id: true, username: true } },
+            song: true,
           },
+          ...whereClause,
         })
         .execute();
     }),
@@ -98,7 +103,7 @@ export const experienceRouter = router({
         data: z.any(),
         status: z.enum(EXPERIENCE_STATUSES),
         version: z.number(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const { id, name, song, data, status, version } = input;
@@ -106,9 +111,9 @@ export const experienceRouter = router({
 
       if (id) {
         // Check if the user has permission to save this experience
-        const userToExperience = await ctx.db.query.usersToExperiences
+        const userToExperience = await ctx.db.query.experiences
           .findFirst({
-            where: eq(usersToExperiences.experienceId, id),
+            where: eq(experiences.userId, ctx.user.id),
           })
           .execute();
 
@@ -132,7 +137,7 @@ export const experienceRouter = router({
       // If no id is provided then we are inserting a new experience
       const [updatedExperience] = await ctx.db
         .insert(experiences)
-        .values({ name, songId, data, status, version })
+        .values({ name, songId, data, status, version, userId: ctx.user.id })
         .onConflictDoNothing({ target: [experiences.name] })
         .returning({ id: experiences.id })
         .execute();
@@ -145,15 +150,6 @@ export const experienceRouter = router({
         });
       }
 
-      await ctx.db
-        .insert(usersToExperiences)
-        .values({
-          userId: ctx.user.id,
-          experienceId: updatedExperience.id,
-        })
-        .onConflictDoNothing()
-        .execute();
-
       return updatedExperience.id;
     }),
 
@@ -162,12 +158,12 @@ export const experienceRouter = router({
       z.object({
         experienceName: z.string(),
         usingLocalData: z.boolean(),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       return await ctx.db.query.experiences
         .findFirst({
-          with: { song: true },
+          with: { user: true, song: true },
           where: eq(experiences.name, input.experienceName),
         })
         .execute();
@@ -178,12 +174,12 @@ export const experienceRouter = router({
       z.object({
         experienceId: z.number(),
         usingLocalData: z.boolean(),
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       return await ctx.db.query.experiences
         .findFirst({
-          with: { song: true },
+          with: { user: true, song: true },
           where: eq(experiences.id, input.experienceId),
         })
         .execute();

--- a/src/types/Experience.ts
+++ b/src/types/Experience.ts
@@ -8,6 +8,8 @@ export type ExperienceStatus = (typeof EXPERIENCE_STATUSES)[number];
 export type Experience = {
   id: number | undefined;
   name: string;
+  // TODO(ben+jeff): we can clean this up later
+  user: { id: number; username: string };
   song: Song;
   status: ExperienceStatus;
   version: number;

--- a/src/types/ExperienceStore.ts
+++ b/src/types/ExperienceStore.ts
@@ -6,10 +6,12 @@ import { NO_SONG } from "@/src/types/Song";
 // Define a new RootStore interface here so that we avoid circular dependencies
 interface RootStore {
   experienceName: string;
+  // TODO(ben+jeff): maybe this can change
+  username: string;
   hasSaved: boolean;
   experienceLastSavedAt: number;
   usingLocalData: boolean;
-  serialize: () => Experience;
+  serialize: () => Omit<Experience, "user">;
   deserialize: (data: Experience) => void;
 }
 
@@ -47,6 +49,8 @@ export class ExperienceStore {
   loadEmptyExperience = () => {
     this.rootStore.deserialize({
       id: undefined,
+      // TODO(ben+jeff): magic number placeholder to appease the typing gods
+      user: { id: -8, username: this.rootStore.username },
       name: "untitled",
       song: NO_SONG,
       status: "inprogress",
@@ -71,7 +75,7 @@ export class ExperienceStore {
       (_, val) =>
         // round numbers to 6 decimal places, which saves space and is probably enough precision
         val?.toFixed ? Number(val.toFixed(6)) : val,
-      pretty ? 2 : 0
+      pretty ? 2 : 0,
     );
 
   copyToClipboard = () => {

--- a/src/types/Store.ts
+++ b/src/types/Store.ts
@@ -41,7 +41,7 @@ export class Store {
   playlistStore = new PlaylistStore(
     this,
     this.audioStore,
-    this.experienceStore
+    this.experienceStore,
   );
   playgroundStore = new PlaygroundStore(this);
 
@@ -81,7 +81,7 @@ export class Store {
 
   get singleBlockSelection(): Block | null {
     const blockSelections = Array.from(this.selectedBlocksOrVariations).filter(
-      (blockOrVariation) => blockOrVariation.type === "block"
+      (blockOrVariation) => blockOrVariation.type === "block",
     ) as BlockSelection[];
 
     return blockSelections.length === 1 ? blockSelections[0].block : null;
@@ -89,9 +89,9 @@ export class Store {
 
   get singleVariationSelection(): VariationSelection | null {
     const variationSelections = Array.from(
-      this.selectedBlocksOrVariations
+      this.selectedBlocksOrVariations,
     ).filter(
-      (blockOrVariation) => blockOrVariation.type === "variation"
+      (blockOrVariation) => blockOrVariation.type === "variation",
     ) as VariationSelection[];
 
     return variationSelections.length === 1 ? variationSelections[0] : null;
@@ -237,7 +237,7 @@ export class Store {
   selectVariation = (
     block: Block,
     uniformName: string,
-    variation: Variation
+    variation: Variation,
   ) => {
     this.selectedBlocksOrVariations = new Set([
       {
@@ -253,7 +253,7 @@ export class Store {
   addVariationToSelection = (
     block: Block,
     uniformName: string,
-    variation: Variation
+    variation: Variation,
   ) => {
     this.selectedBlocksOrVariations.add({
       type: "variation",
@@ -277,7 +277,7 @@ export class Store {
   deselectVariation = (
     block: Block,
     uniformName: string,
-    variation: Variation
+    variation: Variation,
   ) => {
     this.selectedBlocksOrVariations.forEach((selectedBlockOrVariation) => {
       if (
@@ -310,7 +310,7 @@ export class Store {
 
     let blockRemoved = false;
     for (const blockOrVariation of Array.from(
-      this.selectedBlocksOrVariations
+      this.selectedBlocksOrVariations,
     )) {
       if (blockOrVariation.type === "block") {
         // TODO: better generalize for multiple layers
@@ -320,7 +320,7 @@ export class Store {
         this.deleteVariation(
           blockOrVariation.block,
           blockOrVariation.uniformName,
-          blockOrVariation.variation
+          blockOrVariation.variation,
         );
     }
 
@@ -340,7 +340,7 @@ export class Store {
     block: Block,
     uniformName: string,
     variation: Variation,
-    insertAtEnd = false
+    insertAtEnd = false,
   ) => {
     block.duplicateVariation(uniformName, variation, insertAtEnd);
     if (block.layer) this._selectedLayer = block.layer;
@@ -350,7 +350,7 @@ export class Store {
   deleteVariation = (
     block: Block,
     uniformName: string,
-    variation: Variation
+    variation: Variation,
   ) => {
     const removeIndex = block.removeVariation(uniformName, variation);
     const nextVariation = block.findVariationAtIndex(uniformName, removeIndex);
@@ -374,16 +374,16 @@ export class Store {
         Array.from(this.selectedBlocksOrVariations).map((blockOrVariation) =>
           blockOrVariation.type === "block"
             ? blockOrVariation.block.serialize()
-            : blockOrVariation.variation.serialize()
-        )
-      )
+            : blockOrVariation.variation.serialize(),
+        ),
+      ),
     );
   };
 
   // TODO: better generalize for multiple layers
   pasteFromClipboard = (clipboardData: DataTransfer) => {
     const blocksOrVariationsData = JSON.parse(
-      clipboardData.getData("text/plain")
+      clipboardData.getData("text/plain"),
     ) as any[];
     if (!blocksOrVariationsData || !blocksOrVariationsData.length) return;
 
@@ -394,14 +394,14 @@ export class Store {
       if (!layerToPasteInto) return;
 
       const blocksToPaste = blocksOrVariationsData.map((b: any) =>
-        Block.deserialize(this, b)
+        Block.deserialize(this, b),
       );
       blocksToPaste.forEach((block) => block.regenerateId());
       this.selectedBlocksOrVariations = new Set();
       for (const blockToPaste of blocksToPaste) {
         const nextGap = layerToPasteInto.nextFiniteGap(
           this.audioStore.globalTime,
-          blockToPaste.duration
+          blockToPaste.duration,
         );
         blockToPaste.setTiming(nextGap);
         layerToPasteInto.addBlock(blockToPaste);
@@ -414,9 +414,9 @@ export class Store {
 
     // at least one variation must already be selected to know where to paste
     const selectedVariations = Array.from(
-      this.selectedBlocksOrVariations
+      this.selectedBlocksOrVariations,
     ).filter(
-      (blockOrVariation) => blockOrVariation.type === "variation"
+      (blockOrVariation) => blockOrVariation.type === "variation",
     ) as VariationSelection[];
     if (!selectedVariations.length) return;
 
@@ -424,7 +424,7 @@ export class Store {
     const uniformNameToPasteTo = selectedVariations[0].uniformName;
 
     const variationsToPaste = blocksOrVariationsData.map((v) =>
-      deserializeVariation(this, v)
+      deserializeVariation(this, v),
     );
 
     this.selectedBlocksOrVariations = new Set();
@@ -449,7 +449,7 @@ export class Store {
         const newBlock = selectedBlock.clone();
         const nextGap = layerToPasteInto.nextFiniteGap(
           selectedBlock.endTime,
-          selectedBlock.duration
+          selectedBlock.duration,
         );
         newBlock.setTiming(nextGap);
         layerToPasteInto.addBlock(newBlock);
@@ -459,9 +459,9 @@ export class Store {
     }
 
     const selectedVariations = Array.from(
-      this.selectedBlocksOrVariations
+      this.selectedBlocksOrVariations,
     ).filter(
-      (blockOrVariation) => blockOrVariation.type === "variation"
+      (blockOrVariation) => blockOrVariation.type === "variation",
       // TODO: do better type discrimination
     ) as VariationSelection[];
     if (selectedVariations.length > 0) {
@@ -470,7 +470,7 @@ export class Store {
           selectedVariation.block,
           selectedVariation.uniformName,
           selectedVariation.variation,
-          selectedVariations.length > 1
+          selectedVariations.length > 1,
         );
       }
     }
@@ -507,7 +507,8 @@ export class Store {
     }
   };
 
-  serialize = (): Experience => ({
+  // TODO(ben+jeff): using Omit here just to appease the type checker
+  serialize = (): Omit<Experience, "user"> => ({
     id: this.experienceId,
     name: this.experienceName,
     song: this.audioStore.selectedSong,
@@ -523,7 +524,7 @@ export class Store {
     this.experienceStatus = experience.status;
     this.experienceVersion = experience.version;
     this.layers = experience.data.layers.map((l: any) =>
-      Layer.deserialize(this, l)
+      Layer.deserialize(this, l),
     );
 
     // Select first layer

--- a/yarn.lock
+++ b/yarn.lock
@@ -6939,6 +6939,11 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prettier@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
+  integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
+
 process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"


### PR DESCRIPTION
This is a noop refactor purely for styling and DRYing it up:

```
$ yarn db:generate
yarn run v1.22.19
$ drizzle-kit generate --config=drizzle-local.config.ts
Reading config file '/Users/jeff/code/sotsf/conjurer/drizzle-local.config.ts'
5 tables
experiences 8 columns 2 indexes 0 fks
playlists 8 columns 1 indexes 1 fks
songs 6 columns 1 indexes 0 fks
users 5 columns 1 indexes 0 fks
users_to_experiences 5 columns 1 indexes 2 fks

No schema changes, nothing to migrate 😴
✨  Done in 0.43s.
```