### PR TITLE
Introduce "welcome to conjurer" smart playlist that includes all finished experiences 

### DIFF
--- a/src/server/routers/playlistRouter.ts
+++ b/src/server/routers/playlistRouter.ts
@@ -3,7 +3,11 @@ import { z } from "zod";
 import { experiences, playlists, SelectUser } from "@/src/db/schema";
 import { eq, inArray, desc } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
-import { MY_EXPERIENCES_SMART_PLAYLIST, Playlist } from "@/src/types/Playlist";
+import {
+  ALL_FINISHED_SMART_PLAYLIST,
+  MY_EXPERIENCES_SMART_PLAYLIST,
+  Playlist,
+} from "@/src/types/Playlist";
 import { ConjurerDatabase } from "@/src/db/type";
 
 const getMyExperiencesSmartPlaylist = async (ctx: {
@@ -22,6 +26,23 @@ const getMyExperiencesSmartPlaylist = async (ctx: {
   ).map(({ id }) => id),
 });
 
+const getAllFinishedSmartPlaylist = async (ctx: {
+  db: ConjurerDatabase;
+  user: SelectUser;
+}) => ({
+  ...ALL_FINISHED_SMART_PLAYLIST,
+  orderedExperienceIds: (
+    await ctx.db
+      .select({ id: experiences.id })
+      .from(experiences)
+      .where(eq(experiences.status, "complete"))
+      .all()
+  )
+    .map(({ id }) => id)
+    // Shuffle the experiences
+    .sort(() => Math.random() - 0.5),
+});
+
 export const playlistRouter = router({
   getPlaylist: userProcedure
     .input(
@@ -33,6 +54,8 @@ export const playlistRouter = router({
       let playlist: Playlist | undefined;
       if (input.id === MY_EXPERIENCES_SMART_PLAYLIST.id) {
         playlist = await getMyExperiencesSmartPlaylist(ctx);
+      } else if (input.id === ALL_FINISHED_SMART_PLAYLIST.id) {
+        playlist = await getAllFinishedSmartPlaylist(ctx);
       } else {
         playlist = await ctx.db.query.playlists
           .findFirst({
@@ -168,6 +191,10 @@ export const playlistRouter = router({
         ),
       );
 
-      return [await getMyExperiencesSmartPlaylist(ctx), ...sortedPlaylists];
+      return [
+        await getAllFinishedSmartPlaylist(ctx),
+        await getMyExperiencesSmartPlaylist(ctx),
+        ...sortedPlaylists,
+      ];
     }),
 });

--- a/src/types/Playlist.ts
+++ b/src/types/Playlist.ts
@@ -2,9 +2,17 @@ import { CONJURER_USER } from "@/src/types/User";
 
 export const MY_EXPERIENCES_SMART_PLAYLIST = {
   id: -10,
-  name: "My Experiences",
+  name: "Experiences by X",
   description:
     "This is an auto-generated playlist of all the experiences you've created.",
+  user: CONJURER_USER,
+} as const;
+
+export const ALL_FINISHED_SMART_PLAYLIST = {
+  id: -11,
+  name: "Welcome to Conjurer",
+  description:
+    "This is an auto-generated playlist of everyone's finished experiences. Enjoy!",
   user: CONJURER_USER,
 } as const;
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a0d27324-25e1-4d39-b262-6d1d3e6a9e46)

Now the MC page will have a slightly better experience for new users to conjurer: the first playlist that gets selected is an auto generated playlist that includes all finished experiences, called "Welcome to Conjurer". The playlist order is shuffled on every load.

Closes https://github.com/SotSF/conjurer/issues/329