### PR TITLE
Experience thumbnails

### DIFF
--- a/migrations/0005_outgoing_hedge_knight.sql
+++ b/migrations/0005_outgoing_hedge_knight.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `experiences` ADD `thumbnail_url` text DEFAULT '' NOT NULL;

--- a/migrations/meta/0005_snapshot.json
+++ b/migrations/meta/0005_snapshot.json
@@ -1,0 +1,408 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e6d4474f-d300-436f-862b-1481aab19b36",
+  "prevId": "c093586b-52dc-4c9a-990e-740e14a55e19",
+  "tables": {
+    "experiences": {
+      "name": "experiences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inprogress'"
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "experiences_name_unique": {
+          "name": "experiences_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "status_index": {
+          "name": "status_index",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "orderedExperienceIds": {
+          "name": "orderedExperienceIds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "user_id_index": {
+          "name": "user_id_index",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "playlists_user_id_users_id_fk": {
+          "name": "playlists_user_id_users_id_fk",
+          "tableFrom": "playlists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "songs": {
+      "name": "songs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "song_name_artist_index": {
+          "name": "song_name_artist_index",
+          "columns": [
+            "artist",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users_to_experiences": {
+      "name": "users_to_experiences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "experience_id": {
+          "name": "experience_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "user_experience_index": {
+          "name": "user_experience_index",
+          "columns": [
+            "user_id",
+            "experience_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "users_to_experiences_user_id_users_id_fk": {
+          "name": "users_to_experiences_user_id_users_id_fk",
+          "tableFrom": "users_to_experiences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_to_experiences_experience_id_experiences_id_fk": {
+          "name": "users_to_experiences_experience_id_experiences_id_fk",
+          "tableFrom": "users_to_experiences",
+          "tableTo": "experiences",
+          "columnsFrom": [
+            "experience_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1732337100735,
       "tag": "0004_recreate-experiences-table-constraints",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1732343150274,
+      "tag": "0005_outgoing_hedge_knight",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/Canvas/CartesianSpaceView.tsx
+++ b/src/components/Canvas/CartesianSpaceView.tsx
@@ -5,6 +5,8 @@ import fromTexture from "@/src/shaders/fromTexture.frag";
 import { observer } from "mobx-react-lite";
 import { useStore } from "@/src/types/StoreContext";
 import { makeVertexShader } from "@/src/shaders/vertexShader";
+import { useRenderTarget } from "@/src/hooks/renderTarget";
+import { runInAction } from "mobx";
 
 type Props = {
   renderTarget: WebGLRenderTarget;
@@ -16,6 +18,7 @@ export const CartesianSpaceView = observer(function CartesianSpaceView({
   visible,
 }: Props) {
   const store = useStore();
+  const { uiStore } = store;
   const outputMesh = useRef<Mesh>(null);
   const outputUniforms = useRef({
     u_texture: { value: renderTarget.texture },
@@ -39,6 +42,32 @@ export const CartesianSpaceView = observer(function CartesianSpaceView({
     gl.setRenderTarget(null);
     gl.render(outputMesh.current, camera);
   }, 1000);
+
+  // capture the thumbnail
+  const thumbnailRenderTarget = useRenderTarget(64, 64);
+  const buffer = new Uint8Array(64 * 64 * 4);
+  useFrame(({ gl, camera }) => {
+    if (!outputMesh.current || !uiStore.capturingThumbnail) return;
+
+    gl.setRenderTarget(thumbnailRenderTarget);
+    gl.render(outputMesh.current, camera);
+
+    gl.readRenderTargetPixels(thumbnailRenderTarget, 0, 0, 64, 64, buffer);
+
+    // Generate image via data url
+    const canvas = document.createElement("canvas");
+    canvas.width = 64;
+    canvas.height = 64;
+    const context = canvas.getContext("2d")!;
+    // Copy the pixels to a 2D canvas
+    const imageData = context.createImageData(64, 64);
+    console.log(buffer);
+    imageData.data.set(buffer);
+    context.putImageData(imageData, 0, 0);
+    console.log(canvas.toDataURL());
+
+    runInAction(() => (uiStore.capturingThumbnail = false));
+  }, 10000);
 
   return (
     <mesh ref={outputMesh}>

--- a/src/components/Canvas/CartesianSpaceView.tsx
+++ b/src/components/Canvas/CartesianSpaceView.tsx
@@ -5,8 +5,7 @@ import fromTexture from "@/src/shaders/fromTexture.frag";
 import { observer } from "mobx-react-lite";
 import { useStore } from "@/src/types/StoreContext";
 import { makeVertexShader } from "@/src/shaders/vertexShader";
-import { useRenderTarget } from "@/src/hooks/renderTarget";
-import { runInAction } from "mobx";
+import { useCaptureThumbnail } from "@/src/hooks/captureThumbnail";
 
 type Props = {
   renderTarget: WebGLRenderTarget;
@@ -18,7 +17,6 @@ export const CartesianSpaceView = observer(function CartesianSpaceView({
   visible,
 }: Props) {
   const store = useStore();
-  const { uiStore } = store;
   const outputMesh = useRef<Mesh>(null);
   const outputUniforms = useRef({
     u_texture: { value: renderTarget.texture },
@@ -43,35 +41,7 @@ export const CartesianSpaceView = observer(function CartesianSpaceView({
     gl.render(outputMesh.current, camera);
   }, 1000);
 
-  // capture the thumbnail
-  const thumbnailRenderTarget = useRenderTarget(64, 64);
-  const buffer = new Uint8Array(64 * 64 * 4);
-  useFrame(({ gl, camera }) => {
-    if (!outputMesh.current || !uiStore.capturingThumbnail) return;
-
-    gl.setRenderTarget(thumbnailRenderTarget);
-    gl.render(outputMesh.current, camera);
-
-    gl.readRenderTargetPixels(thumbnailRenderTarget, 0, 0, 64, 64, buffer);
-
-    // TODO: toast message reporting successful and reminding to save
-    // Generate image via data url
-    const canvas = document.createElement("canvas");
-    canvas.width = 64;
-    canvas.height = 64;
-    const context = canvas.getContext("2d")!;
-    // Copy the pixels to a 2D canvas
-    const imageData = context.createImageData(64, 64);
-    console.log(buffer);
-    imageData.data.set(buffer);
-    context.putImageData(imageData, 0, 0);
-    const dataURL = canvas.toDataURL();
-
-    runInAction(() => {
-      uiStore.capturingThumbnail = false;
-      store.experienceThumbnailURL = dataURL;
-    });
-  }, 10000);
+  useCaptureThumbnail(outputMesh);
 
   return (
     <mesh ref={outputMesh}>

--- a/src/components/Canvas/CartesianSpaceView.tsx
+++ b/src/components/Canvas/CartesianSpaceView.tsx
@@ -54,6 +54,7 @@ export const CartesianSpaceView = observer(function CartesianSpaceView({
 
     gl.readRenderTargetPixels(thumbnailRenderTarget, 0, 0, 64, 64, buffer);
 
+    // TODO: toast message reporting successful and reminding to save
     // Generate image via data url
     const canvas = document.createElement("canvas");
     canvas.width = 64;
@@ -64,9 +65,12 @@ export const CartesianSpaceView = observer(function CartesianSpaceView({
     console.log(buffer);
     imageData.data.set(buffer);
     context.putImageData(imageData, 0, 0);
-    console.log(canvas.toDataURL());
+    const dataURL = canvas.toDataURL();
 
-    runInAction(() => (uiStore.capturingThumbnail = false));
+    runInAction(() => {
+      uiStore.capturingThumbnail = false;
+      store.experienceThumbnailURL = dataURL;
+    });
   }, 10000);
 
   return (

--- a/src/components/Canvas/DisplayCanvas.tsx
+++ b/src/components/Canvas/DisplayCanvas.tsx
@@ -33,12 +33,10 @@ export const DisplayCanvas = observer(function DisplayCanvas() {
       {renderTarget && (
         <>
           {displayMode === "canopy" && <Canopy renderTarget={renderTarget} />}
-          {displayMode === "cartesianSpace" && (
-            <CartesianSpaceView
-              renderTarget={renderTarget}
-              visible={displayMode === "cartesianSpace"}
-            />
-          )}
+          <CartesianSpaceView
+            renderTarget={renderTarget}
+            visible={displayMode === "cartesianSpace"}
+          />
           <CanopySpaceView
             renderTarget={renderTarget}
             transmitData={!uiStore.patternDrawerOpen}

--- a/src/components/ExperienceEditor/ExperienceEditorControls.tsx
+++ b/src/components/ExperienceEditor/ExperienceEditorControls.tsx
@@ -10,7 +10,7 @@ import { action } from "mobx";
 import { AudioControls } from "@/src/components/AudioControls";
 import { IntensitySlider } from "@/src/components/IntensitySlider";
 import { SendDataButton } from "@/src/components/SendDataButton";
-import { FaShareAlt } from "react-icons/fa";
+import { FaCamera, FaShareAlt } from "react-icons/fa";
 
 export const ExperienceEditorControls = observer(
   function ExperienceEditorControls() {
@@ -101,6 +101,13 @@ export const ExperienceEditorControls = observer(
           height={6}
           icon={<FaShareAlt size={17} />}
           onClick={store.copyLinkToExperience}
+        />
+        <IconButton
+          aria-label="Capture thumbnail"
+          title="Capture thumbnail"
+          height={6}
+          icon={<FaCamera size={17} />}
+          onClick={action(() => (uiStore.capturingThumbnail = true))}
         />
       </HStack>
     );

--- a/src/components/ExperienceEditor/ExperienceEditorControls.tsx
+++ b/src/components/ExperienceEditor/ExperienceEditorControls.tsx
@@ -4,13 +4,12 @@ import { RiZoomInLine, RiZoomOutLine } from "react-icons/ri";
 import { HiZoomIn, HiZoomOut } from "react-icons/hi";
 import { RxAlignCenterHorizontally } from "react-icons/rx";
 import { TbArrowBigRightLines } from "react-icons/tb";
-import { RiPlayList2Fill } from "react-icons/ri";
 import { useStore } from "@/src/types/StoreContext";
 import { action } from "mobx";
 import { AudioControls } from "@/src/components/AudioControls";
 import { IntensitySlider } from "@/src/components/IntensitySlider";
 import { SendDataButton } from "@/src/components/SendDataButton";
-import { FaCamera, FaShareAlt } from "react-icons/fa";
+import { FaShareAlt } from "react-icons/fa";
 
 export const ExperienceEditorControls = observer(
   function ExperienceEditorControls() {
@@ -101,13 +100,6 @@ export const ExperienceEditorControls = observer(
           height={6}
           icon={<FaShareAlt size={17} />}
           onClick={store.copyLinkToExperience}
-        />
-        <IconButton
-          aria-label="Capture thumbnail"
-          title="Capture thumbnail"
-          height={6}
-          icon={<FaCamera size={17} />}
-          onClick={action(() => (uiStore.capturingThumbnail = true))}
         />
       </HStack>
     );

--- a/src/components/ExperienceThumbnail.tsx
+++ b/src/components/ExperienceThumbnail.tsx
@@ -16,12 +16,12 @@ export const ExperienceThumbnail = memo(function ExperienceThumbnail({
   return (
     <Box
       position="relative"
-      cursor="pointer"
       width="32px"
       height="32px"
       borderRadius="50%"
       overflow="hidden"
-      _hover={{ opacity: 0.8 }}
+      cursor={onClick ? "pointer" : undefined}
+      _hover={onClick ? { opacity: 0.8 } : undefined}
       onClick={onClick}
     >
       {!thumbnailURL && captureButton && (

--- a/src/components/ExperienceThumbnail.tsx
+++ b/src/components/ExperienceThumbnail.tsx
@@ -1,40 +1,50 @@
-import { Box } from "@chakra-ui/react";
-import { Experience } from "@/src/types/Experience";
+import { Box, HStack } from "@chakra-ui/react";
 import Image from "next/image";
 import { memo } from "react";
+import { FaCamera } from "react-icons/fa";
 
 export const ExperienceThumbnail = memo(function ExperienceThumbnail({
   thumbnailURL,
   onClick,
+  captureButton = false,
 }: {
   thumbnailURL: string;
   onClick?: () => void;
+  captureButton?: boolean;
 }) {
-  if (!thumbnailURL) return null;
+  if (!thumbnailURL && !captureButton) return null;
   return (
     <Box
       position="relative"
       cursor="pointer"
       width="32px"
       height="32px"
-      onClick={onClick}
-      _hover={{ opacity: 0.8 }}
       borderRadius="50%"
       overflow="hidden"
+      _hover={{ opacity: 0.8 }}
+      onClick={onClick}
     >
-      {/* Black circle where infinity mirror would be */}
-      <Box
-        position="absolute"
-        top="50%"
-        left="50%"
-        transform="translate(-50%,-50%)"
-        width="7px"
-        height="7px"
-        borderRadius="50%"
-        bgColor="#000000"
-        zIndex={10}
-      />
-      <Image src={thumbnailURL} alt="thumbnail" width="32" height="32" />
+      {!thumbnailURL && captureButton && (
+        <HStack justify="center" width="100%" height="100%">
+          <FaCamera size={13} />
+        </HStack>
+      )}
+      {thumbnailURL && (
+        <>
+          {/* Black circle where infinity mirror would be */}
+          <Box
+            position="absolute"
+            top="50%"
+            left="50%"
+            transform="translate(-50%,-50%)"
+            width="6px"
+            height="6px"
+            bgColor="#000000"
+            zIndex={10}
+          />
+          <Image src={thumbnailURL} alt="thumbnail" width="32" height="32" />
+        </>
+      )}
     </Box>
   );
 });

--- a/src/components/ExperienceThumbnail.tsx
+++ b/src/components/ExperienceThumbnail.tsx
@@ -1,0 +1,45 @@
+import { Box } from "@chakra-ui/react";
+import { Experience } from "@/src/types/Experience";
+import Image from "next/image";
+import { memo } from "react";
+
+export const ExperienceThumbnail = memo(function ExperienceThumbnail({
+  experience,
+  onClick,
+}: {
+  experience: Experience;
+  onClick?: () => void;
+}) {
+  if (!experience.thumbnailURL) return null;
+  return (
+    <Box
+      position="relative"
+      cursor="pointer"
+      width="32px"
+      height="32px"
+      onClick={onClick}
+      _hover={{ opacity: 0.8 }}
+      borderRadius="50%"
+      overflow="hidden"
+    >
+      {/* Black circle where infinity mirror would be */}
+      <Box
+        position="absolute"
+        top="50%"
+        left="50%"
+        transform="translate(-50%,-50%)"
+        width="7px"
+        height="7px"
+        borderRadius="50%"
+        bgColor="#000000"
+        zIndex={10}
+      />
+      <Image
+        src={experience.thumbnailURL}
+        alt="thumbnail"
+        width="32"
+        height="32"
+      />
+    </Box>
+  );
+});

--- a/src/components/ExperienceThumbnail.tsx
+++ b/src/components/ExperienceThumbnail.tsx
@@ -4,13 +4,13 @@ import Image from "next/image";
 import { memo } from "react";
 
 export const ExperienceThumbnail = memo(function ExperienceThumbnail({
-  experience,
+  thumbnailURL,
   onClick,
 }: {
-  experience: Experience;
+  thumbnailURL: string;
   onClick?: () => void;
 }) {
-  if (!experience.thumbnailURL) return null;
+  if (!thumbnailURL) return null;
   return (
     <Box
       position="relative"
@@ -34,12 +34,7 @@ export const ExperienceThumbnail = memo(function ExperienceThumbnail({
         bgColor="#000000"
         zIndex={10}
       />
-      <Image
-        src={experience.thumbnailURL}
-        alt="thumbnail"
-        width="32"
-        height="32"
-      />
+      <Image src={thumbnailURL} alt="thumbnail" width="32" height="32" />
     </Box>
   );
 });

--- a/src/components/Menu/MenuBar.tsx
+++ b/src/components/Menu/MenuBar.tsx
@@ -31,6 +31,7 @@ import { useSaveExperience } from "@/src/hooks/experience";
 import { DisplayMode } from "@/src/types/UIStore";
 import { action } from "mobx";
 import { LatencyModal } from "@/src/components/LatencyModal/LatencyModal";
+import { ExperienceThumbnail } from "@/src/components/ExperienceThumbnail";
 
 export const MenuBar = observer(function MenuBar() {
   const store = useStore();
@@ -84,6 +85,7 @@ export const MenuBar = observer(function MenuBar() {
       </Modal>
       <LatencyModal />
       <HStack>
+        <ExperienceThumbnail thumbnailURL={store.experienceThumbnailURL} />
         <Heading
           size="md"
           onClick={() =>

--- a/src/components/Menu/MenuBar.tsx
+++ b/src/components/Menu/MenuBar.tsx
@@ -85,7 +85,11 @@ export const MenuBar = observer(function MenuBar() {
       </Modal>
       <LatencyModal />
       <HStack>
-        <ExperienceThumbnail thumbnailURL={store.experienceThumbnailURL} />
+        <ExperienceThumbnail
+          thumbnailURL={store.experienceThumbnailURL}
+          onClick={action(() => (uiStore.capturingThumbnail = true))}
+          captureButton
+        />
         <Heading
           size="md"
           onClick={() =>

--- a/src/components/Menu/MenuBar.tsx
+++ b/src/components/Menu/MenuBar.tsx
@@ -85,11 +85,16 @@ export const MenuBar = observer(function MenuBar() {
       </Modal>
       <LatencyModal />
       <HStack>
-        <ExperienceThumbnail
-          thumbnailURL={store.experienceThumbnailURL}
-          onClick={action(() => (uiStore.capturingThumbnail = true))}
-          captureButton
-        />
+        {/* TODO: disallow editing if you don't own this experience */}
+        {store.context === "experienceEditor" ? (
+          <ExperienceThumbnail
+            thumbnailURL={store.experienceThumbnailURL}
+            onClick={action(() => (uiStore.capturingThumbnail = true))}
+            captureButton
+          />
+        ) : (
+          <ExperienceThumbnail thumbnailURL={store.experienceThumbnailURL} />
+        )}
         <Heading
           size="md"
           onClick={() =>

--- a/src/components/Menu/OpenExperienceModal.tsx
+++ b/src/components/Menu/OpenExperienceModal.tsx
@@ -52,11 +52,6 @@ export const OpenExperienceModal = observer(function OpenExperienceModal() {
         </ModalHeader>
         <ModalCloseButton />
         <ModalBody>
-          {!isPending && experiences.length === 0 && (
-            <Text color="gray.400">
-              {username} has no saved experiences yet!
-            </Text>
-          )}
           <Switch
             mb={4}
             isChecked={viewingAllExperiences}
@@ -74,6 +69,11 @@ export const OpenExperienceModal = observer(function OpenExperienceModal() {
                 onClose();
               })}
             />
+          )}
+          {!isPending && experiences.length === 0 && (
+            <Text m={4} color="gray.400">
+              {username} has no saved experiences yet!
+            </Text>
           )}
         </ModalBody>
         <ModalFooter>

--- a/src/components/PlaylistEditor/PlaylistEditor.tsx
+++ b/src/components/PlaylistEditor/PlaylistEditor.tsx
@@ -145,9 +145,10 @@ export const PlaylistEditor = observer(function PlaylistEditor() {
         <Table size="sm" variant="simple">
           <Thead>
             <Tr>
-              <Th isNumeric>#</Th>
+              <Th isNumeric></Th>
               <Th>Experience</Th>
-              <Th>Author</Th>
+              {/* <Th>Author</Th> */}
+              <Th>Artist</Th>
               <Th>Song</Th>
               <Th></Th>
             </Tr>
@@ -156,7 +157,7 @@ export const PlaylistEditor = observer(function PlaylistEditor() {
             {playlistExperiences.length === 0 ? (
               <>
                 <Tr>
-                  <Td>-</Td>
+                  <Td></Td>
                   <Td>
                     <Text>No experiences added yet!</Text>
                   </Td>

--- a/src/components/PlaylistEditor/PlaylistEditor.tsx
+++ b/src/components/PlaylistEditor/PlaylistEditor.tsx
@@ -147,7 +147,6 @@ export const PlaylistEditor = observer(function PlaylistEditor() {
             <Tr>
               <Th isNumeric></Th>
               <Th>Experience</Th>
-              {/* <Th>Author</Th> */}
               <Th>Artist</Th>
               <Th>Song</Th>
               <Th></Th>

--- a/src/components/PlaylistEditor/PlaylistItem.tsx
+++ b/src/components/PlaylistEditor/PlaylistItem.tsx
@@ -176,7 +176,7 @@ export const PlaylistItem = observer(function PlaylistItem({
       <Td>
         <HStack>
           <ExperienceThumbnail
-            thumbnailURL={store.experienceThumbnailURL}
+            thumbnailURL={experience.thumbnailURL}
             onClick={onSelect}
           />
           <VStack {...textProps} alignItems="start">

--- a/src/components/PlaylistEditor/PlaylistItem.tsx
+++ b/src/components/PlaylistEditor/PlaylistItem.tsx
@@ -20,6 +20,7 @@ import { Experience } from "@/src/types/Experience";
 import { useSavePlaylist } from "@/src/hooks/playlist";
 import { Playlist } from "@/src/types/Playlist";
 import { reorder } from "@/src/utils/array";
+import { ExperienceThumbnail } from "@/src/components/ExperienceThumbnail";
 
 type PlaylistItemControlsProps = {
   playlist: Playlist;
@@ -173,19 +174,21 @@ export const PlaylistItem = observer(function PlaylistItem({
       </Td>
 
       <Td>
-        <Text {...textProps} fontWeight="bold">
-          {experience.name}
-        </Text>
+        <HStack>
+          <ExperienceThumbnail experience={experience} onClick={onSelect} />
+          <VStack {...textProps} alignItems="start">
+            <Text fontWeight="bold">{experience.name}</Text>
+            <Text>{user.username}</Text>
+          </VStack>
+        </HStack>
       </Td>
 
       <Td>
-        <Text {...textProps}>{user.username}</Text>
+        <Text {...textProps}>{experience.song.artist}</Text>
       </Td>
 
       <Td>
-        <Text {...textProps}>
-          {experience.song.artist} - {experience.song.name}
-        </Text>
+        <Text {...textProps}>{experience.song.name}</Text>
       </Td>
 
       <Td px={0}>

--- a/src/components/PlaylistEditor/PlaylistItem.tsx
+++ b/src/components/PlaylistEditor/PlaylistItem.tsx
@@ -175,7 +175,10 @@ export const PlaylistItem = observer(function PlaylistItem({
 
       <Td>
         <HStack>
-          <ExperienceThumbnail experience={experience} onClick={onSelect} />
+          <ExperienceThumbnail
+            thumbnailURL={store.experienceThumbnailURL}
+            onClick={onSelect}
+          />
           <VStack {...textProps} alignItems="start">
             <Text fontWeight="bold">{experience.name}</Text>
             <Text>{user.username}</Text>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -69,6 +69,7 @@ export const experiences = sqliteTable(
     data: text({ mode: "json" }).notNull(),
     version: integer("version").notNull().default(0),
     userId: integer("user_id").notNull(),
+    thumbnailURL: text("thumbnail_url").notNull().default(""),
 
     ...timestamps,
   },

--- a/src/hooks/captureThumbnail.ts
+++ b/src/hooks/captureThumbnail.ts
@@ -1,0 +1,49 @@
+import { Mesh } from "three";
+import { useFrame } from "@react-three/fiber";
+import { useRenderTarget } from "@/src/hooks/renderTarget";
+import { useStore } from "@/src/types/StoreContext";
+import { runInAction } from "mobx";
+import { useToast } from "@chakra-ui/react";
+import { useSaveExperience } from "@/src/hooks/experience";
+
+export const useCaptureThumbnail = (mesh: { current: Mesh | null }) => {
+  const store = useStore();
+  const { uiStore } = store;
+
+  const toast = useToast();
+  const { saveExperience } = useSaveExperience();
+
+  const thumbnailRenderTarget = useRenderTarget(64, 64);
+  const buffer = new Uint8Array(64 * 64 * 4);
+  useFrame(({ gl, camera }) => {
+    if (!mesh.current || !uiStore.capturingThumbnail) return;
+
+    gl.setRenderTarget(thumbnailRenderTarget);
+    gl.render(mesh.current, camera);
+
+    gl.readRenderTargetPixels(thumbnailRenderTarget, 0, 0, 64, 64, buffer);
+
+    // Generate image via data url
+    const canvas = document.createElement("canvas");
+    canvas.width = 64;
+    canvas.height = 64;
+    const context = canvas.getContext("2d")!;
+    // Copy the pixels to a 2D canvas
+    const imageData = context.createImageData(64, 64);
+    imageData.data.set(buffer);
+    context.putImageData(imageData, 0, 0);
+    const dataURL = canvas.toDataURL();
+
+    runInAction(() => {
+      uiStore.capturingThumbnail = false;
+      store.experienceThumbnailURL = dataURL;
+    });
+
+    toast({
+      title: "Thumbnail updated",
+      status: "info",
+      duration: 2000,
+    });
+    saveExperience({ id: store.experienceId, name: store.experienceName });
+  }, 10000);
+};

--- a/src/hooks/experience.ts
+++ b/src/hooks/experience.ts
@@ -66,6 +66,7 @@ export const useSaveExperience = () => {
 
     utils.experience.listExperiencesForUser.invalidate();
     utils.experience.listExperiences.invalidate();
+    utils.playlist.getPlaylist.invalidate();
   };
 
   return { saveExperience };

--- a/src/server/routers/experienceRouter.ts
+++ b/src/server/routers/experienceRouter.ts
@@ -67,10 +67,11 @@ export const experienceRouter = router({
         data: z.any(),
         status: z.enum(EXPERIENCE_STATUSES),
         version: z.number(),
+        thumbnailURL: z.string(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const { id, name, song, data, status, version } = input;
+      const { id, name, song, data, status, version, thumbnailURL } = input;
       const { id: songId } = song;
 
       if (id) {
@@ -92,7 +93,7 @@ export const experienceRouter = router({
         // If an id is provided then we are updating an existing experience
         await ctx.db
           .update(experiences)
-          .set({ name, songId, data, status, version })
+          .set({ name, songId, data, status, version, thumbnailURL })
           .where(eq(experiences.id, id))
           .execute();
         return id;

--- a/src/server/routers/experienceRouter.ts
+++ b/src/server/routers/experienceRouter.ts
@@ -42,7 +42,13 @@ export const experienceRouter = router({
 
       return await ctx.db.query.experiences
         .findMany({
-          columns: { id: true, name: true, status: true, version: true },
+          columns: {
+            id: true,
+            name: true,
+            status: true,
+            version: true,
+            thumbnailURL: true,
+          },
           with: {
             user: { columns: { id: true, username: true } },
             song: true,

--- a/src/server/routers/playlistRouter.ts
+++ b/src/server/routers/playlistRouter.ts
@@ -80,7 +80,13 @@ export const playlistRouter = router({
       const playlistExperiences = await ctx.db.query.experiences
         .findMany({
           where: inArray(experiences.id, playlist.orderedExperienceIds),
-          columns: { id: true, name: true, status: true, version: true },
+          columns: {
+            id: true,
+            name: true,
+            status: true,
+            version: true,
+            thumbnailURL: true,
+          },
           with: {
             user: { columns: { id: true, username: true } },
             song: true,

--- a/src/types/Experience.ts
+++ b/src/types/Experience.ts
@@ -14,4 +14,5 @@ export type Experience = {
   status: ExperienceStatus;
   version: number;
   data?: any;
+  thumbnailURL: string;
 };

--- a/src/types/ExperienceStore.ts
+++ b/src/types/ExperienceStore.ts
@@ -44,6 +44,7 @@ export class ExperienceStore {
       status: "inprogress",
       version: EXPERIENCE_VERSION,
       data: { layers: [{ patternBlocks: [] }, { patternBlocks: [] }] },
+      thumbnailURL: "",
     });
 
     this.store.hasSaved = false;

--- a/src/types/Store.ts
+++ b/src/types/Store.ts
@@ -131,6 +131,7 @@ export class Store {
   experienceVersion = EXPERIENCE_VERSION;
   experienceStatus: ExperienceStatus = "inprogress";
   experienceId: number | undefined = undefined;
+  experienceThumbnailURL = "";
 
   get playing() {
     return this.audioStore.audioState !== "paused";
@@ -484,6 +485,7 @@ export class Store {
     status: this.experienceStatus,
     version: this.experienceVersion,
     data: { layers: this.layers.map((l) => l.serialize()) },
+    thumbnailURL: this.experienceThumbnailURL,
   });
 
   deserialize = (experience: Experience) => {
@@ -492,6 +494,7 @@ export class Store {
     this.audioStore.selectedSong = experience.song || NO_SONG;
     this.experienceStatus = experience.status;
     this.experienceVersion = experience.version;
+    this.experienceThumbnailURL = experience.thumbnailURL;
     this.layers = experience.data.layers.map((l: any) =>
       Layer.deserialize(this, l),
     );

--- a/src/types/UIStore.ts
+++ b/src/types/UIStore.ts
@@ -26,6 +26,7 @@ export class UIStore {
   showingSaveBeatMapModal = false;
   showingLoadBeatMapModal = false;
   showingLatencyModal = false;
+  capturingThumbnail = false;
 
   pendingAction: "open" | "save" | "" = "";
 


### PR DESCRIPTION
Closes #328 

Introduces experience thumbnails! Such a great idea by @jeffawang.

![image](https://github.com/user-attachments/assets/15096fec-3998-43ed-8e87-f9835609e9ce)

From the experience editor page, you simply click the camera icon next to the experience name to save the thumbnail.
![image](https://github.com/user-attachments/assets/fcfcdc99-92ec-4566-a816-15d4e5186c90)

They are being saved as data URLs for now, but we can store them in s3 in the future.