### PR TITLE
add ExperienceStatusIndicator UI element to experiences list item and…

### DIFF
--- a/src/components/ExperienceStatusIndicator.tsx
+++ b/src/components/ExperienceStatusIndicator.tsx
@@ -1,0 +1,29 @@
+import { HStack, Text } from "@chakra-ui/react";
+import { ExperienceStatus } from "@/src/types/Experience";
+
+type ExperienceStatusProps = {
+  experienceStatus: ExperienceStatus;
+  withLabel?: boolean;
+};
+
+export const ExperienceStatusIndicator = ({
+  experienceStatus,
+  withLabel,
+}: ExperienceStatusProps) => {
+  switch (experienceStatus) {
+    case "inprogress":
+      return (
+        <HStack>
+          <Text>🟡</Text>
+          {withLabel && <Text>In Progress</Text>}
+        </HStack>
+      );
+    case "complete":
+      return (
+        <HStack>
+          <Text>🟢</Text>
+          {withLabel && <Text>Complete</Text>}
+        </HStack>
+      );
+  }
+};

--- a/src/components/Menu/MenuBar.tsx
+++ b/src/components/Menu/MenuBar.tsx
@@ -32,6 +32,7 @@ import { DisplayMode } from "@/src/types/UIStore";
 import { action } from "mobx";
 import { LatencyModal } from "@/src/components/LatencyModal/LatencyModal";
 import { ExperienceThumbnail } from "@/src/components/ExperienceThumbnail";
+import { ExperienceStatusIndicator } from "../ExperienceStatusIndicator";
 
 export const MenuBar = observer(function MenuBar() {
   const store = useStore();
@@ -366,6 +367,24 @@ export const MenuBar = observer(function MenuBar() {
               Report an issue
             </MenuItem>
           </MenuList>
+          <Button
+            as={Button}
+            px={1}
+            py={0}
+            variant="ghost"
+            size="xs"
+            transition="all 0.2s"
+            borderRadius="md"
+            _hover={{ bg: "gray.500" }}
+            _focus={{ boxShadow: "outline" }}
+          >
+            <Text fontSize="xs">
+              <ExperienceStatusIndicator
+                experienceStatus={store.experienceStatus}
+                withLabel
+              />
+            </Text>
+          </Button>
         </Menu>
       </HStack>
     </VStack>

--- a/src/components/PlaylistEditor/PlaylistEditor.tsx
+++ b/src/components/PlaylistEditor/PlaylistEditor.tsx
@@ -147,6 +147,7 @@ export const PlaylistEditor = observer(function PlaylistEditor() {
             <Tr>
               <Th isNumeric></Th>
               <Th>Experience</Th>
+              <Th>Status</Th>
               <Th>Artist</Th>
               <Th>Song</Th>
               <Th></Th>

--- a/src/components/PlaylistEditor/PlaylistItem.tsx
+++ b/src/components/PlaylistEditor/PlaylistItem.tsx
@@ -16,11 +16,12 @@ import { useStore } from "@/src/types/StoreContext";
 import { observer } from "mobx-react-lite";
 import { useRouter } from "next/router";
 import { ImCross } from "react-icons/im";
-import { Experience } from "@/src/types/Experience";
+import { Experience, ExperienceStatus } from "@/src/types/Experience";
 import { useSavePlaylist } from "@/src/hooks/playlist";
 import { Playlist } from "@/src/types/Playlist";
 import { reorder } from "@/src/utils/array";
 import { ExperienceThumbnail } from "@/src/components/ExperienceThumbnail";
+import { ExperienceStatusIndicator } from "../ExperienceStatusIndicator";
 
 type PlaylistItemControlsProps = {
   playlist: Playlist;
@@ -183,6 +184,12 @@ export const PlaylistItem = observer(function PlaylistItem({
             <Text fontWeight="bold">{experience.name}</Text>
             <Text>{user.username}</Text>
           </VStack>
+        </HStack>
+      </Td>
+
+      <Td>
+        <HStack {...textProps} justify="center">
+          <ExperienceStatusIndicator experienceStatus={experience.status} />
         </HStack>
       </Td>
 


### PR DESCRIPTION
… experience editor menu bar

Eg:

<img width="503" alt="Screenshot 2024-11-26 at 7 36 58 PM" src="https://github.com/user-attachments/assets/c368f36a-30d6-4830-822c-511c213e94de">


<img width="414" alt="Screenshot 2024-11-26 at 7 37 30 PM" src="https://github.com/user-attachments/assets/ad25a63d-fa50-4b37-94d4-d8397eff1af5">
