### PR TITLE
Initial loading state / better navigation

### DIFF
--- a/src/components/ExperienceEditor/ExperienceEditorPage.tsx
+++ b/src/components/ExperienceEditor/ExperienceEditorPage.tsx
@@ -1,7 +1,7 @@
 import { Arrangement } from "@/src/components/Arrangement";
 import { Box } from "@chakra-ui/react";
 import { Display } from "@/src/components/Display";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { useStore } from "@/src/types/StoreContext";
 import { observer } from "mobx-react-lite";
 import { KeyboardControls } from "@/src/components/KeyboardControls";

--- a/src/components/ExperienceEditor/ExperienceEditorPage.tsx
+++ b/src/components/ExperienceEditor/ExperienceEditorPage.tsx
@@ -1,7 +1,7 @@
 import { Arrangement } from "@/src/components/Arrangement";
 import { Box } from "@chakra-ui/react";
 import { Display } from "@/src/components/Display";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useStore } from "@/src/types/StoreContext";
 import { observer } from "mobx-react-lite";
 import { KeyboardControls } from "@/src/components/KeyboardControls";
@@ -13,15 +13,39 @@ import { LoadingOverlay } from "@/src/components/LoadingOverlay";
 
 export const ExperienceEditorPage = observer(function ExperienceEditorPage() {
   const store = useStore();
-  const { uiStore, experienceStore } = store;
+  const { uiStore, experienceStore, initializationState } = store;
+  const { loadingExperienceName } = experienceStore;
 
   const router = useRouter();
   useEffect(() => {
-    if (store.initializedClientSide || !router.query.experienceName) return;
+    if (initializationState !== "uninitialized" || !router.isReady) return;
+
+    console.log("initial load", router.query.experienceName);
     store.initializeClientSide(router.query.experienceName as string);
   }, [
     store,
+    initializationState,
     experienceStore,
+    store.experienceName,
+    router.query.experienceName,
+  ]);
+
+  useEffect(() => {
+    if (
+      initializationState !== "initialized" ||
+      !router.query.experienceName ||
+      store.experienceName === router.query.experienceName ||
+      loadingExperienceName === router.query.experienceName
+    )
+      return;
+
+    console.log("subsequent load", router.query.experienceName);
+    experienceStore.load(router.query.experienceName as string);
+  }, [
+    store,
+    experienceStore,
+    initializationState,
+    loadingExperienceName,
     store.experienceName,
     router.query.experienceName,
   ]);

--- a/src/components/ExperienceEditor/ExperienceEditorPage.tsx
+++ b/src/components/ExperienceEditor/ExperienceEditorPage.tsx
@@ -17,19 +17,21 @@ export const ExperienceEditorPage = observer(function ExperienceEditorPage() {
   const { loadingExperienceName } = experienceStore;
 
   const router = useRouter();
+
+  // Initialize the store with the experience name from the URL
   useEffect(() => {
     if (initializationState !== "uninitialized" || !router.isReady) return;
-
-    console.log("initial load", router.query.experienceName);
     store.initializeClientSide(router.query.experienceName as string);
   }, [
     store,
     initializationState,
     experienceStore,
     store.experienceName,
+    router.isReady,
     router.query.experienceName,
   ]);
 
+  // Listen for url changes and load any new experience by name
   useEffect(() => {
     if (
       initializationState !== "initialized" ||
@@ -38,8 +40,6 @@ export const ExperienceEditorPage = observer(function ExperienceEditorPage() {
       loadingExperienceName === router.query.experienceName
     )
       return;
-
-    console.log("subsequent load", router.query.experienceName);
     experienceStore.load(router.query.experienceName as string);
   }, [
     store,

--- a/src/components/ExperienceThumbnail.tsx
+++ b/src/components/ExperienceThumbnail.tsx
@@ -6,13 +6,13 @@ import { FaCamera } from "react-icons/fa";
 export const ExperienceThumbnail = memo(function ExperienceThumbnail({
   thumbnailURL,
   onClick,
-  captureButton = false,
+  showCaptureButton = false,
 }: {
   thumbnailURL: string;
   onClick?: () => void;
-  captureButton?: boolean;
+  showCaptureButton?: boolean;
 }) {
-  if (!thumbnailURL && !captureButton) return null;
+  if (!thumbnailURL && !showCaptureButton) return null;
   return (
     <Box
       position="relative"
@@ -24,7 +24,7 @@ export const ExperienceThumbnail = memo(function ExperienceThumbnail({
       _hover={onClick ? { opacity: 0.8 } : undefined}
       onClick={onClick}
     >
-      {!thumbnailURL && captureButton && (
+      {!thumbnailURL && showCaptureButton && (
         <HStack justify="center" width="100%" height="100%">
           <FaCamera size={13} />
         </HStack>

--- a/src/components/KeyboardControls.tsx
+++ b/src/components/KeyboardControls.tsx
@@ -2,6 +2,7 @@ import { useSaveExperience } from "@/src/hooks/experience";
 import { useStore } from "@/src/types/StoreContext";
 import { action } from "mobx";
 import { observer } from "mobx-react-lite";
+import { useRouter } from "next/router";
 import { useEffect } from "react";
 
 type Props = {
@@ -14,6 +15,7 @@ export const KeyboardControls = observer(function KeyboardControls({
   const store = useStore();
   const { uiStore, experienceStore, audioStore } = store;
 
+  const router = useRouter();
   const { saveExperience } = useSaveExperience();
 
   useEffect(() => {
@@ -25,7 +27,7 @@ export const KeyboardControls = observer(function KeyboardControls({
         saveExperience();
         e.preventDefault();
       } else if (editMode && e.key === "n" && (e.ctrlKey || e.metaKey)) {
-        experienceStore.loadEmptyExperience();
+        experienceStore.openEmptyExperience(router);
         e.preventDefault();
       }
 

--- a/src/components/KeyboardControls.tsx
+++ b/src/components/KeyboardControls.tsx
@@ -97,7 +97,15 @@ export const KeyboardControls = observer(function KeyboardControls({
       window.removeEventListener("copy", handleCopy);
       window.removeEventListener("paste", handlePaste);
     };
-  }, [store, uiStore, experienceStore, audioStore, editMode, saveExperience]);
+  }, [
+    store,
+    uiStore,
+    experienceStore,
+    audioStore,
+    editMode,
+    saveExperience,
+    router,
+  ]);
 
   return null;
 });

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -21,7 +21,9 @@ export const LoadingOverlay = observer(function LoadingOverlay() {
   const { context, role } = store;
   return (
     <Modal
-      isOpen={!contextMatchesRole(context, role)}
+      isOpen={
+        !store.initializedClientSide || !contextMatchesRole(context, role)
+      }
       onClose={() => {}}
       closeOnEsc={false}
       closeOnOverlayClick={false}

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -18,11 +18,13 @@ const contextMatchesRole = (context: Context, role: Role) => {
 
 export const LoadingOverlay = observer(function LoadingOverlay() {
   const store = useStore();
-  const { context, role } = store;
+  const { context, role, experienceStore } = store;
   return (
     <Modal
       isOpen={
-        !store.initializedClientSide || !contextMatchesRole(context, role)
+        store.initializationState !== "initialized" ||
+        experienceStore.loadingExperienceName !== null ||
+        !contextMatchesRole(context, role)
       }
       onClose={() => {}}
       closeOnEsc={false}

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -21,11 +21,13 @@ import { observer } from "mobx-react-lite";
 import { trpc } from "@/src/utils/trpc";
 import { sanitize } from "@/src/utils/sanitize";
 import { CONJURER_USER } from "@/src/types/User";
+import { useRouter } from "next/router";
 
 export const LoginButton = observer(function LoginButton() {
   const store = useStore();
   const { experienceStore, uiStore, userStore, usingLocalData } = store;
 
+  const router = useRouter();
   const [newUsername, setNewUsername] = useState("");
 
   const {
@@ -80,7 +82,7 @@ export const LoginButton = observer(function LoginButton() {
                       width="100%"
                       onClick={action(() => {
                         userStore.me = user;
-                        experienceStore.loadEmptyExperience();
+                        experienceStore.openEmptyExperience(router);
                         if (store.context === "experienceEditor") {
                           uiStore.showingOpenExperienceModal = true;
                         }
@@ -110,7 +112,7 @@ export const LoginButton = observer(function LoginButton() {
                     username: newUsername,
                   });
                   userStore.me = newUser;
-                  experienceStore.loadEmptyExperience();
+                  experienceStore.openEmptyExperience(router);
                   onClose();
                 })}
               >

--- a/src/components/Menu/MenuBar.tsx
+++ b/src/components/Menu/MenuBar.tsx
@@ -373,17 +373,16 @@ export const MenuBar = observer(function MenuBar() {
             py={0}
             variant="ghost"
             size="xs"
+            fontSize="xs"
             transition="all 0.2s"
             borderRadius="md"
             _hover={{ bg: "gray.500" }}
             _focus={{ boxShadow: "outline" }}
           >
-            <Text fontSize="xs">
-              <ExperienceStatusIndicator
-                experienceStatus={store.experienceStatus}
-                withLabel
-              />
-            </Text>
+            <ExperienceStatusIndicator
+              experienceStatus={store.experienceStatus}
+              withLabel
+            />
           </Button>
         </Menu>
       </HStack>

--- a/src/components/Menu/MenuBar.tsx
+++ b/src/components/Menu/MenuBar.tsx
@@ -91,7 +91,7 @@ export const MenuBar = observer(function MenuBar() {
           <ExperienceThumbnail
             thumbnailURL={store.experienceThumbnailURL}
             onClick={action(() => (uiStore.capturingThumbnail = true))}
-            captureButton
+            showCaptureButton
           />
         ) : (
           <ExperienceThumbnail thumbnailURL={store.experienceThumbnailURL} />

--- a/src/components/Menu/MenuBar.tsx
+++ b/src/components/Menu/MenuBar.tsx
@@ -86,8 +86,7 @@ export const MenuBar = observer(function MenuBar() {
       </Modal>
       <LatencyModal />
       <HStack>
-        {/* TODO: disallow editing if you don't own this experience */}
-        {store.context === "experienceEditor" ? (
+        {store.context === "experienceEditor" && store.canEditExperience ? (
           <ExperienceThumbnail
             thumbnailURL={store.experienceThumbnailURL}
             onClick={action(() => (uiStore.capturingThumbnail = true))}

--- a/src/components/Menu/MenuBar.tsx
+++ b/src/components/Menu/MenuBar.tsx
@@ -33,11 +33,13 @@ import { action } from "mobx";
 import { LatencyModal } from "@/src/components/LatencyModal/LatencyModal";
 import { ExperienceThumbnail } from "@/src/components/ExperienceThumbnail";
 import { ExperienceStatusIndicator } from "../ExperienceStatusIndicator";
+import { useRouter } from "next/router";
 
 export const MenuBar = observer(function MenuBar() {
   const store = useStore();
   const { audioStore, experienceStore, uiStore } = store;
 
+  const router = useRouter();
   const { saveExperience } = useSaveExperience();
 
   const {
@@ -168,7 +170,9 @@ export const MenuBar = observer(function MenuBar() {
                     <MenuItem
                       icon={<FaFile size={17} />}
                       command="⌘N"
-                      onClick={experienceStore.loadEmptyExperience}
+                      onClick={() =>
+                        experienceStore.openEmptyExperience(router)
+                      }
                     >
                       New experience
                     </MenuItem>

--- a/src/components/Menu/OpenExperienceModal.tsx
+++ b/src/components/Menu/OpenExperienceModal.tsx
@@ -21,7 +21,7 @@ import { useRouter } from "next/router";
 
 export const OpenExperienceModal = observer(function OpenExperienceModal() {
   const store = useStore();
-  const { uiStore, userStore } = store;
+  const { uiStore, userStore, experienceStore } = store;
   const { username } = userStore;
 
   const [viewingAllExperiences, setViewingAllExperiences] = useState(false);
@@ -62,9 +62,7 @@ export const OpenExperienceModal = observer(function OpenExperienceModal() {
             <ExperiencesTable
               experiences={experiences}
               onClickExperience={action(async (experience) => {
-                router.push(`/experience/${experience.name}`, undefined, {
-                  shallow: true,
-                });
+                experienceStore.openExperience(router, experience.name);
                 onClose();
               })}
             />

--- a/src/components/Menu/OpenExperienceModal.tsx
+++ b/src/components/Menu/OpenExperienceModal.tsx
@@ -17,19 +17,21 @@ import { action } from "mobx";
 import { useState } from "react";
 import { ExperiencesTable } from "@/src/components/ExperiencesTable/ExperiencesTable";
 import { useExperiences } from "@/src/hooks/experiencesAndUsers";
+import { useRouter } from "next/router";
 
 export const OpenExperienceModal = observer(function OpenExperienceModal() {
   const store = useStore();
-  const { experienceStore, uiStore, userStore } = store;
+  const { uiStore, userStore } = store;
   const { username } = userStore;
 
   const [viewingAllExperiences, setViewingAllExperiences] = useState(false);
-  const [isLoadingNewExperience, setIsLoadingNewExperience] = useState(false);
 
   const { isPending, isError, isRefetching, experiences } = useExperiences({
     username: viewingAllExperiences ? undefined : username,
     enabled: uiStore.showingOpenExperienceModal,
   });
+
+  const router = useRouter();
 
   const onClose = action(() => (uiStore.showingOpenExperienceModal = false));
 
@@ -45,10 +47,7 @@ export const OpenExperienceModal = observer(function OpenExperienceModal() {
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>
-          Open experience{" "}
-          {(isPending || isRefetching || isLoadingNewExperience) && (
-            <Spinner ml={2} />
-          )}
+          Open experience {(isPending || isRefetching) && <Spinner ml={2} />}
         </ModalHeader>
         <ModalCloseButton />
         <ModalBody>
@@ -63,9 +62,9 @@ export const OpenExperienceModal = observer(function OpenExperienceModal() {
             <ExperiencesTable
               experiences={experiences}
               onClickExperience={action(async (experience) => {
-                setIsLoadingNewExperience(true);
-                await experienceStore.load(experience.name);
-                setIsLoadingNewExperience(false);
+                router.push(`/experience/${experience.name}`, undefined, {
+                  shallow: true,
+                });
                 onClose();
               })}
             />

--- a/src/components/PlaygroundPage.tsx
+++ b/src/components/PlaygroundPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { PatternPlayground } from "@/src/components/PatternPlayground/PatternPlayground";
 import { useStore } from "@/src/types/StoreContext";
 import { observer } from "mobx-react-lite";
@@ -10,15 +10,13 @@ import { LoginButton } from "@/src/components/LoginButton";
 export const PlaygroundPage = observer(function PlaygroundPage() {
   const store = useStore();
 
-  const initialized = useRef(false);
   useEffect(() => {
-    if (initialized.current) return;
-    initialized.current = true;
+    if (store.initializationState !== "uninitialized") return;
     store.initializeClientSide();
-  }, [store]);
+  }, [store, store.initializationState]);
 
   return (
-    store.initializedClientSide && (
+    store.initializationState === "initialized" && (
       <>
         <HStack
           p={2}

--- a/src/components/PlaylistEditor/PlaylistEditor.tsx
+++ b/src/components/PlaylistEditor/PlaylistEditor.tsx
@@ -121,7 +121,7 @@ export const PlaylistEditor = observer(function PlaylistEditor() {
           leftIcon={<FaPlus size={14} />}
           onClick={() => {
             store.role = "experienceCreator";
-            router.push("/experience/untitled");
+            experienceStore.openEmptyExperience(router);
           }}
         >
           New experience

--- a/src/components/PlaylistEditor/PlaylistEditorPage.tsx
+++ b/src/components/PlaylistEditor/PlaylistEditorPage.tsx
@@ -15,9 +15,9 @@ export const PlaylistEditorPage = observer(function PlaylistEditorPage() {
   const { userStore } = store;
 
   useEffect(() => {
-    if (store.initializedClientSide) return;
+    if (store.initializationState !== "uninitialized") return;
     store.initializeClientSide();
-  }, [store]);
+  }, [store, store.initializationState]);
 
   return (
     <Box position="relative" w="100vw" h="100vh">

--- a/src/components/PlaylistEditor/PlaylistItem.tsx
+++ b/src/components/PlaylistEditor/PlaylistItem.tsx
@@ -166,7 +166,7 @@ export const PlaylistItem = observer(function PlaylistItem({
             icon={<FaPencilAlt size={10} />}
             onClick={action(() => {
               store.role = "experienceCreator";
-              router.push(`/experience/${experience.name}`);
+              experienceStore.openExperience(router, experience.name);
             })}
           />
           {editable && (

--- a/src/components/RoleSelector.tsx
+++ b/src/components/RoleSelector.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/router";
 
 export const RoleSelector = observer(function RoleSelector() {
   const store = useStore();
+  const { experienceStore } = store;
   const router = useRouter();
   return (
     <Menu computePositionOnMount size="xs">
@@ -36,7 +37,7 @@ export const RoleSelector = observer(function RoleSelector() {
         <MenuItem
           onClick={action(() => {
             store.role = "experienceCreator";
-            router.push(`/experience/${store.experienceName || "untitled"}`);
+            experienceStore.openExperience(router, store.experienceName);
           })}
         >
           Experience Creator

--- a/src/types/ExperienceStore.ts
+++ b/src/types/ExperienceStore.ts
@@ -38,7 +38,7 @@ export class ExperienceStore {
   loadEmptyExperience = () => {
     this.store.deserialize({
       id: undefined,
-      user: this.store.userStore.me ?? { id: 0, username: "" },
+      user: this.store.userStore.me ?? { id: -1, username: "" },
       name: "untitled",
       song: NO_SONG,
       status: "inprogress",

--- a/src/types/ExperienceStore.ts
+++ b/src/types/ExperienceStore.ts
@@ -5,6 +5,14 @@ import { NO_SONG } from "@/src/types/Song";
 import type { Store } from "@/src/types/Store";
 
 export class ExperienceStore {
+  private _loadingExperienceName: string | null = null;
+  get loadingExperienceName() {
+    return this._loadingExperienceName;
+  }
+  set loadingExperienceName(value: string | null) {
+    this._loadingExperienceName = value;
+  }
+
   constructor(readonly store: Store) {
     makeAutoObservable(this);
   }
@@ -18,12 +26,14 @@ export class ExperienceStore {
   };
 
   load = async (experienceName: string) => {
+    this.loadingExperienceName = experienceName;
     const experience = await trpcClient.experience.getExperience.query({
       experienceName,
       usingLocalData: this.store.usingLocalData,
     });
     if (!experience) this.loadEmptyExperience();
     else this.loadExperience(experience);
+    this.loadingExperienceName = null;
   };
 
   loadById = async (experienceId: number) => {

--- a/src/types/Store.ts
+++ b/src/types/Store.ts
@@ -1,6 +1,6 @@
 import { Block } from "@/src/types/Block";
 import { UIStore } from "@/src/types/UIStore";
-import { makeAutoObservable, runInAction } from "mobx";
+import { makeAutoObservable } from "mobx";
 import { AudioStore } from "@/src/types/AudioStore";
 import { Variation } from "@/src/types/Variations/Variation";
 import { ExperienceStore } from "@/src/types/ExperienceStore";
@@ -35,9 +35,6 @@ export type BlockOrVariation = BlockSelection | VariationSelection;
 type InitializationState = "uninitialized" | "initializing" | "initialized";
 
 export class Store {
-  initializedClientSide = false;
-  initializationState: InitializationState = "uninitialized";
-
   audioStore = new AudioStore(this);
   beatMapStore = new BeatMapStore(this);
   uiStore = new UIStore(this);
@@ -50,6 +47,14 @@ export class Store {
 
   sendingData = false;
   viewerMode = false;
+
+  private _initializationState: InitializationState = "uninitialized";
+  get initializationState() {
+    return this._initializationState;
+  }
+  set initializationState(value: InitializationState) {
+    this._initializationState = value;
+  }
 
   _globalIntensity = 1;
   get globalIntensity(): number {
@@ -153,9 +158,7 @@ export class Store {
 
   initializeClientSide = async (initialExperienceName?: string) => {
     if (this.initializationState !== "uninitialized") return;
-    runInAction(() => {
-      this.initializationState = "initializing";
-    });
+    this.initializationState = "initializing";
 
     if (process.env.NEXT_PUBLIC_ENABLE_VOICE === "true")
       setupVoiceCommandWebsocket(this);
@@ -200,7 +203,7 @@ export class Store {
     else if (this.context !== "playlistEditor")
       this.experienceStore.loadEmptyExperience();
 
-    runInAction(() => (this.initializationState = "initialized"));
+    this.initializationState = "initialized";
   };
 
   toggleSendingData = () => {

--- a/src/types/Store.ts
+++ b/src/types/Store.ts
@@ -125,11 +125,6 @@ export class Store {
     this._experienceName = value;
     if (this.context === "experienceEditor") {
       localStorage.setItem("experienceName", value);
-      window.history.replaceState(
-        window.history.state,
-        "",
-        `/experience/${value}`,
-      );
     }
   }
 


### PR DESCRIPTION
Closes #334, #335, #343

Improves the navigation UX, including showing the loading overlay while initializing the app and loading an experience. Should also fix all of the browser back/forward navigation issues.
