### PR TITLE
Add Color Remap effect

### DIFF
--- a/src/effects/ColorRemap.ts
+++ b/src/effects/ColorRemap.ts
@@ -1,0 +1,75 @@
+import { Pattern } from "@/src/types/Pattern";
+import colorRemap from "./shaders/colorRemap.frag";
+import { Palette } from "@/src/params/palette/Palette";
+import { Vector3 } from "three";
+
+export { colorRemap };
+export const ColorRemap = () =>
+  new Pattern(
+    "Color Remap",
+    colorRemap,
+    {
+      u_hue_shift: {
+        name: "Hue Shift",
+        value: 0,
+        min: 0,
+        max: 1,
+        step: 0.01,
+      },
+      u_saturation: {
+        name: "Saturation",
+        value: 1,
+        min: 0,
+        max: 2,
+        step: 0.01,
+      },
+      u_invert: {
+        name: "Invert",
+        value: 0,
+        min: 0,
+        max: 1,
+        step: 0.01,
+      },
+      u_posterize: {
+        name: "Posterize",
+        value: 0,
+        min: 0,
+        max: 32,
+        step: 1,
+        jumpy: true,
+      },
+      u_palette: {
+        name: "Palette",
+        // Classic full-spectrum cosine palette (Inigo Quilez), so gradient-map mode reads as a
+        // rainbow out of the box until the artist dials in their own gradient.
+        value: new Palette(
+          new Vector3(0.5, 0.5, 0.5),
+          new Vector3(0.5, 0.5, 0.5),
+          new Vector3(1, 1, 1),
+          new Vector3(0, 0.33, 0.67),
+        ),
+      },
+      u_palette_mix: {
+        name: "Palette Mix",
+        value: 0,
+        min: 0,
+        max: 1,
+        step: 0.01,
+      },
+      u_mask_lo: {
+        name: "Mask Low",
+        value: 0,
+        min: 0,
+        max: 1,
+        step: 0.01,
+      },
+      u_mask_hi: {
+        name: "Mask High",
+        value: 0,
+        min: 0,
+        max: 1,
+        step: 0.01,
+      },
+    },
+    ["v_normalized_uv"],
+  );

--- a/src/effects/effects.ts
+++ b/src/effects/effects.ts
@@ -12,6 +12,7 @@ import { BrightnessAdjust } from "./BrightnessAdjust";
 import { Kaleidoscope } from "@/src/effects/Kaleidoscope";
 import { ShapeMask } from "@/src/effects/ShapeMask";
 import { Threshold } from "@/src/effects/Threshold";
+import { ColorRemap } from "@/src/effects/ColorRemap";
 
 const effectFactories: Array<() => Pattern> = [
   ShapeMask,
@@ -21,6 +22,7 @@ const effectFactories: Array<() => Pattern> = [
   BrightnessAdjust,
   Threshold,
   ColorTint,
+  ColorRemap,
   CartesianProjection,
   Rotate,
   ChromaticAberration,

--- a/src/effects/shaders/colorRemap.frag
+++ b/src/effects/shaders/colorRemap.frag
@@ -1,0 +1,75 @@
+#include <conjurer_common>
+
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+varying vec2 v_normalized_uv;
+uniform sampler2D u_texture;
+
+uniform float u_hue_shift;
+uniform float u_saturation;
+uniform float u_invert;
+uniform float u_posterize;
+uniform Palette u_palette;
+uniform float u_palette_mix;
+uniform float u_mask_lo;
+uniform float u_mask_hi;
+
+// // For debugging
+// #define u_hue_shift 0.5
+// #define u_saturation 1.
+// #define u_invert 0.
+// #define u_posterize 0.
+// #define u_palette Palette(vec3(0.5), vec3(0.5), vec3(1.), vec3(0., 0.33, 0.67))
+// #define u_palette_mix 0.
+// #define u_mask_lo 0.
+// #define u_mask_hi 0.
+
+// rgb -> hsv. Not provided by conjurer_common (which only has the hsv->rgb `hsv()` helper).
+vec3 rgb2hsv(vec3 c) {
+    vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+    vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+    vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+    float d = q.x - min(q.w, q.y);
+    float e = 1.0e-10;
+    return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+
+void main() {
+    vec4 sampled = texture2D(u_texture, v_normalized_uv);
+    vec3 rgb = sampled.rgb;
+
+    // Perceptual luminance of the ORIGINAL pixel. Drives both the palette lookup (gradient-map
+    // mode) and the mask/blend weight, so the transform can be gated or faded by brightness.
+    float luminance = dot(rgb, vec3(0.299, 0.587, 0.114));
+
+    // --- Hue rotation + saturation, done in HSV so brightness/shape are preserved ---
+    // u_hue_shift is a fraction of a full turn (1.0 = 360deg). Black has v==0, so rotating its
+    // hue is a no-op -- shadows never pick up false color.
+    vec3 hsvColor = rgb2hsv(rgb);
+    hsvColor.x = fract(hsvColor.x + u_hue_shift);
+    hsvColor.y = clamp(hsvColor.y * u_saturation, 0.0, 1.0);
+    vec3 color = hsv(hsvColor.x, hsvColor.y, hsvColor.z);
+
+    // --- Solarize / tone-reversal: blend toward the per-channel inverse ---
+    color = mix(color, 1.0 - color, u_invert);
+
+    // --- Posterize: quantize each channel to N discrete levels (0 or 1 = off) ---
+    if (u_posterize >= 2.0) {
+        color = floor(clamp(color, 0.0, 1.0) * u_posterize) / (u_posterize - 1.0);
+        color = clamp(color, 0.0, 1.0);
+    }
+
+    // --- Gradient map: remap the original luminance through an arbitrary palette ---
+    vec3 mapped = palette(luminance, u_palette);
+    color = mix(color, mapped, u_palette_mix);
+
+    // --- Luminance mask: how strongly the transform applies to this pixel ---
+    // Defaults (lo=hi=0) leave pure black untouched but transform everything else fully. Raising
+    // the band turns this into a "apply by brightness" fade instead of a hard black-guard.
+    float hi = max(u_mask_hi, u_mask_lo + 1e-4);
+    float weight = smoothstep(u_mask_lo, hi, luminance);
+
+    gl_FragColor = vec4(mix(rgb, color, weight), sampled.a);
+}


### PR DESCRIPTION
## What

A general per-pixel **color-remap effect** that takes a pattern's rendered output and transforms its colors without changing the underlying brightness, shape, or motion. Motivating use case: take the Fire pattern's reds/oranges and shift them to a blue flame — and, more broadly, arbitrarily remap one color scheme to another (the psychedelic color-state switching of the *2001: A Space Odyssey* stargate sequence).

## How

`ColorRemap` is a standard effect `Pattern` (`src/effects/ColorRemap.ts` + `shaders/colorRemap.frag`), registered in `effects.ts`. Per pixel the shader:

1. Samples the upstream texture and computes the original luminance.
2. Rotates hue and scales saturation in **HSV** (brightness/shape preserved; black is a no-op, so shadows never pick up false color).
3. Blends toward a tone-inverted **solarize** look.
4. **Posterizes** to N discrete levels.
5. Optionally **gradient-maps** the original luminance through a `Palette`.
6. Mixes the result back over the original by a **luminance-mask** weight.

| Param | Range | Effect |
|---|---|---|
| Hue Shift | 0–1 (full turn) | rotate hue (fire → blue flame) |
| Saturation | 0–2 | saturation multiplier |
| Invert | 0–1 | blend toward tone-inverted / solarized |
| Posterize | 0–32 | quantize to N levels (0/1 = off) |
| Palette | Palette | gradient-map source luminance through a cosine palette |
| Palette Mix | 0–1 | blend amount for the palette map |
| Mask Low / High | 0–1 | luminance band the transform applies within; defaults leave pure black untouched |

Every param is a plain `number` or `Palette`, so it plugs into the existing param UI (device panel, timeline automation lanes, curve/LFO/audio regions, palette editor) with **no new UI infrastructure**. Driving Hue Shift or Invert with a square-wave LFO or a hard-step curve reproduces the discrete color-state switching of the 2001 sequence — no preset system needed.

## Testing

- `tsc --noEmit` clean.
- Dev server boots; editor route compiles cleanly (glslify `#include <conjurer_common>` resolves, effect present in the bundle).
- Verified in-browser: added onto a pattern block via the device panel and confirmed it renders / recolors as expected.

## Examples

<img width="1510" height="712" alt="image" src="https://github.com/user-attachments/assets/10b0aa04-7dd7-4a02-b101-fb9c984afb0a" />
<img width="420" height="333" alt="image" src="https://github.com/user-attachments/assets/58ba35c6-faf1-46c0-acda-87c09edb27a0" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)