### PR TITLE
Variable playback speed (0.25× / 0.5× / 1×) transport control

### DIFF
--- a/src/components/PlayHead.tsx
+++ b/src/components/PlayHead.tsx
@@ -54,10 +54,12 @@ export const PlayHead = observer(function PlayHead() {
 
     // Account for the zoom level. The distance the playhead travels stays the same, 144000px.
     // The duration of the animation changes based on the zoom level.
+    // Also scale by playbackRate so the playhead slows in lockstep with the audio
+    // (the CSS animation runs on wall-clock time, so it must be stretched when slowed).
     playHead.current.style.animationDuration = `${
-      144000 / uiStore.pixelsPerSecond
+      144000 / (uiStore.pixelsPerSecond * audioStore.playbackRate)
     }s`;
-  }, [audioStore.lastCursor, uiStore.pixelsPerSecond]);
+  }, [audioStore.lastCursor, uiStore.pixelsPerSecond, audioStore.playbackRate]);
 
   return (
     <Box

--- a/src/components/Timeline/TimerControls.tsx
+++ b/src/components/Timeline/TimerControls.tsx
@@ -1,9 +1,17 @@
 import { observer } from "mobx-react-lite";
-import { ButtonGroup, HStack, IconButton, VStack } from "@chakra-ui/react";
+import {
+  Button,
+  ButtonGroup,
+  HStack,
+  IconButton,
+  VStack,
+} from "@chakra-ui/react";
 import { FaPlay, FaPause, FaStepForward, FaStepBackward } from "react-icons/fa";
 import { useStore } from "@/src/types/StoreContext";
 import { action } from "mobx";
 import { MdForward10, MdReplay10 } from "react-icons/md";
+
+const PLAYBACK_RATES = [0.25, 0.5, 1] as const;
 
 export const TimerControls = observer(function TimerControls() {
   const store = useStore();
@@ -83,6 +91,33 @@ export const TimerControls = observer(function TimerControls() {
               icon={<MdForward10 size={17} />}
               onClick={action(() => audioStore.skip(10))}
             />
+          </ButtonGroup>
+        </HStack>
+      )}
+      {showSkipButtons && (
+        <HStack width="100%" justify="center" overflowX="clip">
+          <ButtonGroup isAttached>
+            {PLAYBACK_RATES.map((rate) => {
+              const active = audioStore.playbackRate === rate;
+              return (
+                <Button
+                  key={rate}
+                  borderStyle="solid"
+                  borderWidth={1}
+                  aria-label={`Set playback speed to ${rate}x`}
+                  title={`Set playback speed to ${rate}x`}
+                  height={5}
+                  minWidth={9}
+                  px={2}
+                  fontSize="xs"
+                  color={active ? "green" : "white"}
+                  bgColor={active ? "gray.500" : "gray.600"}
+                  onClick={action(() => (audioStore.playbackRate = rate))}
+                >
+                  {rate}x
+                </Button>
+              );
+            })}
           </ButtonGroup>
         </HStack>
       )}

--- a/src/components/Timeline/TimerControls.tsx
+++ b/src/components/Timeline/TimerControls.tsx
@@ -1,9 +1,9 @@
 import { observer } from "mobx-react-lite";
 import {
-  Button,
   ButtonGroup,
   HStack,
   IconButton,
+  Select,
   VStack,
 } from "@chakra-ui/react";
 import { FaPlay, FaPause, FaStepForward, FaStepBackward } from "react-icons/fa";
@@ -11,7 +11,7 @@ import { useStore } from "@/src/types/StoreContext";
 import { action } from "mobx";
 import { MdForward10, MdReplay10 } from "react-icons/md";
 
-const PLAYBACK_RATES = [0.25, 0.5, 1] as const;
+const PLAYBACK_RATES = [1, 0.5, 0.25] as const;
 
 export const TimerControls = observer(function TimerControls() {
   const store = useStore();
@@ -69,7 +69,7 @@ export const TimerControls = observer(function TimerControls() {
         </ButtonGroup>
       </HStack>
       {showSkipButtons && (
-        <HStack width="100%" justify="center" overflowX="clip">
+        <HStack width="100%" justify="center" overflowX="clip" spacing={1}>
           <ButtonGroup isAttached>
             <IconButton
               borderStyle="solid"
@@ -77,6 +77,7 @@ export const TimerControls = observer(function TimerControls() {
               aria-label="Go back 10 seconds "
               title="Go back 10 seconds "
               height={6}
+              minWidth={7}
               bgColor="gray.600"
               icon={<MdReplay10 size={17} />}
               onClick={action(() => audioStore.skip(-10))}
@@ -87,38 +88,34 @@ export const TimerControls = observer(function TimerControls() {
               aria-label="Go forward 10 seconds"
               title="Go forward 10 seconds"
               height={6}
+              minWidth={7}
               bgColor="gray.600"
               icon={<MdForward10 size={17} />}
               onClick={action(() => audioStore.skip(10))}
             />
           </ButtonGroup>
-        </HStack>
-      )}
-      {showSkipButtons && (
-        <HStack width="100%" justify="center" overflowX="clip">
-          <ButtonGroup isAttached>
-            {PLAYBACK_RATES.map((rate) => {
-              const active = audioStore.playbackRate === rate;
-              return (
-                <Button
-                  key={rate}
-                  borderStyle="solid"
-                  borderWidth={1}
-                  aria-label={`Set playback speed to ${rate}x`}
-                  title={`Set playback speed to ${rate}x`}
-                  height={5}
-                  minWidth={9}
-                  px={2}
-                  fontSize="xs"
-                  color={active ? "green" : "white"}
-                  bgColor={active ? "gray.500" : "gray.600"}
-                  onClick={action(() => (audioStore.playbackRate = rate))}
-                >
-                  {rate}x
-                </Button>
-              );
+          <Select
+            aria-label="Playback speed"
+            title="Playback speed"
+            size="xs"
+            width="16"
+            height={6}
+            borderStyle="solid"
+            borderWidth={1}
+            bgColor="gray.600"
+            borderRadius="md"
+            iconSize="14px"
+            value={audioStore.playbackRate}
+            onChange={action((e) => {
+              audioStore.playbackRate = Number(e.target.value);
             })}
-          </ButtonGroup>
+          >
+            {PLAYBACK_RATES.map((rate) => (
+              <option key={rate} value={rate}>
+                {rate}×
+              </option>
+            ))}
+          </Select>
         </HStack>
       )}
     </VStack>

--- a/src/components/Wavesurfer/WavesurferWaveform.tsx
+++ b/src/components/Wavesurfer/WavesurferWaveform.tsx
@@ -55,7 +55,9 @@ const WavesurferWaveform = observer(function WavesurferWaveform() {
   // Keep Wavesurfer's React prop stable so layout zoom doesn't force an
   // immediate redraw; we drive zoom imperatively (debounced) instead.
   const initialMinPxPerSecRef = useRef(
-    uiStore.canTimelineZoom ? uiStore.pixelsPerSecond : INITIAL_PIXELS_PER_SECOND,
+    uiStore.canTimelineZoom
+      ? uiStore.pixelsPerSecond
+      : INITIAL_PIXELS_PER_SECOND,
   );
 
   const cloneCanvas = useCloneCanvas(clonedWaveformRef);
@@ -235,6 +237,8 @@ const WavesurferWaveform = observer(function WavesurferWaveform() {
             audioStore.wavesurfer = wavesurfer;
             if (audioStore.audioMuted) wavesurfer.setMuted(true);
             wavesurfer.setVolume(audioStore.audioVolume);
+            // re-apply rate: wavesurfer remounts (e.g. song switch) reset it to 1
+            wavesurfer.setPlaybackRate(audioStore.playbackRate, true);
             if (uiStore.canTimelineZoom) {
               setTimelineLabelIntervals(
                 audioStore.timelinePlugin,

--- a/src/types/AudioStore.ts
+++ b/src/types/AudioStore.ts
@@ -51,6 +51,10 @@ export class AudioStore {
     this._playbackRate = rate;
     // preservePitch keeps the chant recognizable when slowed
     this.wavesurfer?.setPlaybackRate(rate, true);
+    // The timeline playhead is a wall-clock CSS animation anchored at lastCursor;
+    // changing rate restarts that animation, so re-anchor it to the live position
+    // (works paused or playing) to keep it from jumping back to the old anchor.
+    this.lastCursorPosition = this._globalTime;
     this.saveToLocalStorage();
   }
 

--- a/src/types/AudioStore.ts
+++ b/src/types/AudioStore.ts
@@ -43,6 +43,17 @@ export class AudioStore {
     this.wavesurfer?.setVolume(volume);
   }
 
+  private _playbackRate = 1;
+  get playbackRate() {
+    return this._playbackRate;
+  }
+  set playbackRate(rate: number) {
+    this._playbackRate = rate;
+    // preservePitch keeps the chant recognizable when slowed
+    this.wavesurfer?.setPlaybackRate(rate, true);
+    this.saveToLocalStorage();
+  }
+
   wavesurfer: WaveSurfer | null = null;
   timelinePlugin: TimelinePlugin | null = null;
   minimapPlugin: MinimapPlugin | null = null;
@@ -83,6 +94,7 @@ export class AudioStore {
       const localStorageAudioSettings = JSON.parse(data);
       this.audioLatency =
         localStorageAudioSettings.audioLatency || INITIAL_AUDIO_LATENCY;
+      this.playbackRate = localStorageAudioSettings.playbackRate || 1;
     }
   };
 
@@ -92,6 +104,7 @@ export class AudioStore {
       "audioStore",
       JSON.stringify({
         audioLatency: this.audioLatency,
+        playbackRate: this.playbackRate,
       }),
     );
   };


### PR DESCRIPTION
Adds a variable playback-speed control to the transport so songs can be played at reduced rates for detailed timeline work.

Closes #312

## What

- **`AudioStore.playbackRate`** — new persisted getter/setter. Applies the rate to wavesurfer with `preservePitch` so the audio stays recognizable when slowed, re-anchors the timeline playhead on change (works paused or playing), and survives page reloads via localStorage.
- **Transport dropdown** (`TimerControls`) — a `1× / 0.5× / 0.25×` selector next to the skip buttons.
- **Wavesurfer remount fix** — re-applies the rate after remounts (e.g. song switch), which otherwise reset it to `1`.
- **Playhead sync** (`PlayHead`) — scales the CSS playhead animation duration by the playback rate so the wall-clock-driven playhead slows in lockstep with the audio.

## Origin

Cherry-picked from the `playback-rate` branch (commits `fb23618`, `4edd105`), which originally forked from the current `main` tip and was previously merged into the MCP editing-API branch. Because it forked from `main`, it applies here with no dependency on that work.

## Notes

- Scope is small and self-contained: +60/-5 across 4 files.
- One incidental prettier-reformat hunk in `WavesurferWaveform.tsx` (the `initialMinPxPerSecRef` ternary) — cosmetic.
- Feature was previously exercised as part of the editing-API branch, not standalone on main — worth a quick smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
