### PR TITLE
Randomize playground pattern parameters

### DIFF
--- a/src/components/PatternPlayground/ParameterControls.tsx
+++ b/src/components/PatternPlayground/ParameterControls.tsx
@@ -4,17 +4,32 @@ import { Block } from "@/src/types/Block";
 import { PatternParam } from "@/src/params/shared/patternParam";
 import { BsArrowsCollapse, BsArrowsExpand } from "react-icons/bs";
 import { ParameterControl } from "@/src/components/PatternPlayground/ParameterControl";
+import { randomizeBlockParameters } from "@/src/utils/randomizeBlockParameters";
 
 type ParameterControlsProps = {
   block: Block;
+  // Bumped whenever parameters are randomized (including from a sibling ParameterControls,
+  // e.g. randomizing a pattern also randomizes its applied effects), to remount each
+  // ParameterControl below — they hold local input state that doesn't otherwise react to
+  // param values changing out from under them.
+  randomizeNonce?: number;
+  onRandomize?: () => void;
 };
 
 export const ParameterControls = memo(function ParameterControls({
   block,
+  randomizeNonce = 0,
+  onRandomize,
 }: ParameterControlsProps) {
   const [showControls, toggleControls] = useState(true);
 
   const isEffect = block.parentBlock !== null;
+
+  const onRandomizeClick = () => {
+    randomizeBlockParameters(block);
+    onRandomize?.();
+  };
+
   return (
     <VStack
       spacing={0}
@@ -32,13 +47,18 @@ export const ParameterControls = memo(function ParameterControls({
         >
           {showControls ? <BsArrowsCollapse /> : <BsArrowsExpand />}
         </Button>
+        {!isEffect && (
+          <Button size="xs" ml={2} onClick={onRandomizeClick}>
+            Randomize
+          </Button>
+        )}
       </Heading>
 
       {showControls &&
         Object.entries<PatternParam>(block.pattern.params).map(
           ([uniformName, patternParam]) => (
             <ParameterControl
-              key={uniformName}
+              key={`${uniformName}-${randomizeNonce}`}
               block={block}
               uniformName={uniformName}
               patternParam={patternParam}

--- a/src/components/PatternPlayground/PatternPlayground.tsx
+++ b/src/components/PatternPlayground/PatternPlayground.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, HStack, VStack } from "@chakra-ui/react";
 import { PatternList } from "@/src/components/PatternPlayground/PatternList";
 import { PreviewCanvas } from "@/src/components/Canvas/PreviewCanvas";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ParameterControls } from "@/src/components/PatternPlayground/ParameterControls";
 import { observer } from "mobx-react-lite";
 import { useStore } from "@/src/types/StoreContext";
@@ -23,6 +23,11 @@ export const PatternPlayground = observer(function PatternPlayground() {
     lastEffectIndices,
     selectedPatternBlock,
   } = playgroundStore;
+
+  // Bumped whenever parameters are randomized, so both the pattern's and its applied
+  // effects' ParameterControls remount together and pick up the new values.
+  const [randomizeNonce, setRandomizeNonce] = useState(0);
+  const onRandomize = useCallback(() => setRandomizeNonce((n) => n + 1), []);
 
   const applyPatternEffects = useCallback(
     (patternIndex: number, effectIndices: number[]) => {
@@ -155,11 +160,14 @@ export const PatternPlayground = observer(function PatternPlayground() {
                 <ParameterControls
                   key={selectedPatternBlock.id}
                   block={selectedPatternBlock}
+                  randomizeNonce={randomizeNonce}
+                  onRandomize={onRandomize}
                 />
                 {selectedEffectIndices.map((effectIndex, i) => (
                   <ParameterControls
                     key={`${effectBlocks[effectIndex].id}-${i}`}
                     block={effectBlocks[effectIndex]}
+                    randomizeNonce={randomizeNonce}
                   />
                 ))}
               </VStack>

--- a/src/utils/randomizeBlockParameters.ts
+++ b/src/utils/randomizeBlockParameters.ts
@@ -1,0 +1,78 @@
+import { runInAction } from "mobx";
+
+import { Block } from "@/src/types/Block";
+import { BASE_UNIFORMS } from "@/src/types/Pattern";
+import { FlatVariation } from "@/src/types/Variations/FlatVariation";
+import { LinearVariation4 } from "@/src/types/Variations/LinearVariation4";
+import { PaletteVariation } from "@/src/params/palette/variation/PaletteVariation";
+import { DEFAULT_VARIATION_DURATION } from "@/src/utils/time";
+import { isBooleanParam } from "@/src/params/boolean/isBooleanParam";
+import { isNumberParam } from "@/src/params/number/isNumberParam";
+import { isVector4Param } from "@/src/params/vector4/isVector4Param";
+import { isPaletteParam } from "@/src/params/palette/isPaletteParam";
+
+const round2 = (value: number) => Math.round(value * 100) / 100;
+
+function setFlatVariation(block: Block, uniformName: string, value: number) {
+  if (!block.parameterVariations[uniformName])
+    block.parameterVariations[uniformName] = [];
+  block.parameterVariations[uniformName]![0] = new FlatVariation(
+    DEFAULT_VARIATION_DURATION,
+    value,
+  );
+}
+
+function randomizeParams(block: Block): void {
+  for (const [uniformName, param] of Object.entries(block.pattern.params)) {
+    if (BASE_UNIFORMS.includes(uniformName)) continue;
+
+    if (isBooleanParam(param)) {
+      const value = Math.random() < 0.5 ? 0 : 1;
+      param.value = value;
+      setFlatVariation(block, uniformName, value);
+    } else if (isNumberParam(param)) {
+      const min = typeof param.min === "number" ? param.min : 0;
+      const max = typeof param.max === "number" ? param.max : 1;
+      const value = round2(min + Math.random() * (max - min));
+      param.value = value;
+      setFlatVariation(block, uniformName, value);
+    } else if (isVector4Param(param)) {
+      param.value.set(Math.random(), Math.random(), Math.random(), 1);
+
+      if (!block.parameterVariations[uniformName])
+        block.parameterVariations[uniformName] = [];
+      block.parameterVariations[uniformName]![0] = new LinearVariation4(
+        DEFAULT_VARIATION_DURATION,
+        param.value,
+        param.value,
+      );
+    } else if (isPaletteParam(param)) {
+      param.value.randomize();
+
+      // Keep the PaletteVariation in sync with the randomized param value.
+      // The param editor reads the palette from this variation (a clone), not
+      // from param.value, so without this the swatch/raw values show stale data
+      // even though the preview — which reads param.value — updates. Mirrors the
+      // number/vec4 branches above and PaletteParameterControl.updatePaletteVariation.
+      if (!block.parameterVariations[uniformName])
+        block.parameterVariations[uniformName] = [];
+      block.parameterVariations[uniformName]![0] = new PaletteVariation(
+        DEFAULT_VARIATION_DURATION,
+        param.value,
+      );
+    }
+  }
+}
+
+/**
+ * Randomizes every parameter on a pattern block (and any effect blocks currently
+ * applied to it) in place, keeping `parameterVariations` in sync the same way each
+ * param type's own control does (see {@link setBlockNumberParameterValue},
+ * `ColorParameterControl`, `Palette.randomize`).
+ */
+export function randomizeBlockParameters(block: Block): void {
+  runInAction(() => {
+    randomizeParams(block);
+    block.effectBlocks.forEach(randomizeParams);
+  });
+}


### PR DESCRIPTION
Adds a **"Randomize" button** to the playground pattern parameter panel. It randomizes every parameter on the selected pattern block and its applied effects in place — numbers to a random value in `[min, max]` (rounded to 2 decimals), booleans to 0/1, vec4 to a random color, palettes via `Palette.randomize()` — and bumps a `randomizeNonce` so the parameter controls remount and reflect the new values.

### Also fixes a palette staleness bug
The palette editor reads its palette from the param's `PaletteVariation` (a **clone**), not from `param.value`. Randomizing only `param.value` therefore left the editor's swatch and raw values **stale**, even though the preview canopy — which reads `param.value` — updated. The palette branch now syncs the `PaletteVariation` too, matching how the number/vec4 branches already sync their variations.

### Scope
- `src/utils/randomizeBlockParameters.ts` (new) — randomize logic + the palette-variation sync
- `PatternPlayground/ParameterControls.tsx` — Randomize button + `randomizeNonce` remount
- `PatternPlayground/PatternPlayground.tsx` — `randomizeNonce` state threading

**Scoped entirely to the `/playground` sandbox** — mutates in-memory playground blocks only; no data-model, serialization, or render-pipeline changes, so saved experiences are unaffected. Second independently-mergeable slice extracted from the larger editor-overhaul branch (after #385).

### Verification
- ✅ `tsc --noEmit` · ✅ `next lint` · ✅ `next build`
- ⚠️ Not yet done: manual click-through of Randomize in the running playground (incl. confirming the palette editor now updates live) — worth a quick check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
