### PR TITLE
Shape Mask: add inner radius and theta arc params

### DIFF
--- a/src/effects/ShapeMask.ts
+++ b/src/effects/ShapeMask.ts
@@ -8,9 +8,35 @@ export const ShapeMask = () =>
     "Shape Mask",
     shapeMask,
     {
+      u_inner_radius: {
+        name: "Inner radius",
+        value: 0,
+        min: 0,
+        max: 1,
+        step: 0.01,
+      },
+      // Data name kept as u_radius for backwards compatibility; displayed as
+      // "Outer radius" now that an inner radius exists.
       u_radius: {
-        name: "Radius",
+        name: "Outer radius",
         value: 0.5,
+        min: 0,
+        max: 1,
+        step: 0.01,
+      },
+      u_theta_min: {
+        name: "Theta min",
+        value: 0,
+        min: 0,
+        max: 360,
+        step: 1,
+      },
+      u_theta_max: {
+        name: "Theta max",
+        value: 360,
+        min: 0,
+        max: 360,
+        step: 1,
       },
       u_inverse: {
         name: "Inverse",

--- a/src/effects/shaders/shapeMask.frag
+++ b/src/effects/shaders/shapeMask.frag
@@ -8,20 +8,46 @@ varying vec2 v_uv;
 varying vec2 v_normalized_uv;
 uniform sampler2D u_texture;
 
+uniform float u_inner_radius;
 uniform float u_radius;
+uniform float u_theta_min;
+uniform float u_theta_max;
 uniform float u_inverse;
 
 // // For debugging
+// #define u_inner_radius 0.0
 // #define u_radius 0.5
+// #define u_theta_min 0.0
+// #define u_theta_max 360.0
 // #define u_inverse 0.0
 
 void main() {
     vec2 st = v_uv;
     st = cartesianToCanopyProjection(st);
+    // In canopy coordinates: st.y is the radial distance (0 = apex, 1 = outer
+    // edge) and st.x is the angle around the center, normalized to 0..1.
 
-    float circle = 1.0 - step(u_radius, st.y);
-    float inverse = 1.0 - circle;
-    float intensity = mix(circle, inverse, u_inverse);
+    // Radial band: keep pixels between the inner and outer radius. The default
+    // inner radius of 0 keeps the full inner disc, matching legacy behavior
+    // (visible where st.y < u_radius).
+    float radial = step(u_inner_radius, st.y) * (1.0 - step(u_radius, st.y));
+
+    // Angular arc: keep pixels between the min and max angle (in degrees). The
+    // default range of 0..360 covers the full circle, matching legacy behavior.
+    float theta = st.x * 360.0;
+    float aboveMin = step(u_theta_min, theta); // theta >= u_theta_min
+    float belowMax = step(theta, u_theta_max); // theta <= u_theta_max
+    float arc;
+    if (u_theta_min <= u_theta_max) {
+        arc = aboveMin * belowMax;
+    } else {
+        // Wrapped arc crossing 0 degrees (e.g. min = 350, max = 10).
+        arc = clamp(aboveMin + belowMax, 0.0, 1.0);
+    }
+
+    float mask = radial * arc;
+    float inverse = 1.0 - mask;
+    float intensity = mix(mask, inverse, u_inverse);
 
     vec4 sampled = texture2D(u_texture, v_normalized_uv);
     vec3 masked = sampled.xyz * intensity;


### PR DESCRIPTION
## Why

The Shape Mask effect could only express a filled disc: it exposed a single `Radius` param, and the inner edge was always pinned to the innermost section of the canopy. It also always applied across the full 360°. That makes two common shapes impossible — a donut (ring) section, and a wedge/arc covering only part of the canopy.

## What

Adds three params to Shape Mask, and renames one label:

- **Inner radius** (`u_inner_radius`, default `0`) — a radial floor, so the mask can show only a donut section of the image instead of always including the center.
- **Theta min / Theta max** (`u_theta_min` / `u_theta_max`, default `0` / `360` degrees) — restricts the mask to an arbitrary arc rather than the full circle. Arcs that wrap across 0° (e.g. min `350`, max `10`) are handled.
- **Radius → "Outer radius"** — display label only. The data name stays `u_radius`.

In the shader, the mask is now the product of a radial band (`inner_radius <= st.y < radius`) and an angular arc, replacing the single `step(u_radius, st.y)` cutoff. `Inverse` continues to flip the whole composed mask.

## Backwards compatibility

Every new default reproduces current rendering exactly:

- `u_inner_radius = 0` — `step(0, st.y)` is `1` everywhere, so the full inner disc is kept, leaving the old `st.y < u_radius` behavior untouched.
- `u_theta_min = 0`, `u_theta_max = 360` — covers the entire circle. The upper bound is inclusive (`step(theta, u_theta_max)`) specifically so the seam at exactly 360° isn't masked.

Renaming only the display label keeps `u_radius` values in saved experiences loading correctly.

Existing saved experiences predate these params, so their serialized data lacks them. That's safe here: `Block.deserialize` starts from a clone of the current effect definition and overlays only the keys present in the saved data, and `updateParameters` iterates only over saved variations — so a param with no saved variation retains its default from `ShapeMask.ts`. Nothing ends up undefined.

I also gave the radius params explicit `min`/`max`/`step` slider bounds (they previously had none). That's UI-only and does not affect rendering.

## Testing

- `tsc --noEmit` passes clean.
- Ran the dev server against this branch and loaded the app (page compiles, shader loads without error). Confirmed the five params show up on a Shape Mask block and that existing blocks render as before until the new sliders are moved.

Note that edges stay hard (no feathering), consistent with the existing step-based mask, and theta is expressed in degrees with `0°` at the existing `st.x = 0` seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)