### PR TITLE
Add saw waves to periodic LFO variations

### DIFF
--- a/src/components/VariationControls/VariationControls.tsx
+++ b/src/components/VariationControls/VariationControls.tsx
@@ -29,18 +29,28 @@ type PeriodicVariationControlsProps = {
   onChange?: () => void;
 };
 
-const WAVE_TYPES: { type: PeriodicVariationType; label: string }[] = [
-  { type: "sine", label: "Sine" },
-  { type: "square", label: "Square" },
-  { type: "triangle", label: "Triangle" },
+// Wrapped into rows of three: five segments across the 160px param panel would
+// leave ~30px each, too narrow for labels like "Triangle".
+const WAVE_ROWS: { type: PeriodicVariationType; label: string }[][] = [
+  [
+    { type: "sine", label: "Sine" },
+    { type: "square", label: "Square" },
+    { type: "triangle", label: "Triangle" },
+  ],
+  [
+    { type: "sawUp", label: "Saw ↑" },
+    { type: "sawDown", label: "Saw ↓" },
+  ],
 ];
 
-// Small matching waveform glyphs, hand-drawn so all three share one stroke
+// Small matching waveform glyphs, hand-drawn so they all share one stroke
 // style (react-icons has no triangle-wave, and mixing weights looks off).
 const WAVE_PATHS: Record<PeriodicVariationType, string> = {
   sine: "M1 8 Q 3.5 1 6 8 T 11 8 T 16 8",
   square: "M1 13 V3 H6 V13 H11 V3 H16",
   triangle: "M1 13 L4.5 3 L8 13 L11.5 3 L15 13",
+  sawUp: "M1 13 L8 3 V13 L15 3 V13",
+  sawDown: "M1 3 L8 13 V3 L15 13 V3",
 };
 
 function WaveGlyph({ type }: { type: PeriodicVariationType }) {
@@ -188,27 +198,39 @@ export function PeriodicVariationControls({
   return (
     <VStack spacing={2} align="stretch" w="100%">
       <ControlSection label="Waveform" first>
-        <HStack spacing={0} w="100%">
-          {WAVE_TYPES.map(({ type, label }, i) => (
-            <SegmentButton
-              key={type}
-              active={periodicType === type}
-              first={i === 0}
-              last={i === WAVE_TYPES.length - 1}
-              ariaLabel={label}
-              onClick={() => {
-                setPeriodicType(type);
-                variation.periodicType = type;
-                block.triggerVariationReactions(uniformName);
-              }}
-            >
-              <VStack spacing={0}>
-                <WaveGlyph type={type} />
-                <Text fontSize="8px">{label}</Text>
-              </VStack>
-            </SegmentButton>
+        <VStack spacing={1} align="stretch" w="100%">
+          {WAVE_ROWS.map((row, rowIndex) => (
+            <HStack key={rowIndex} spacing={0} w="100%">
+              {row.map(({ type, label }, i) => (
+                <SegmentButton
+                  key={type}
+                  active={periodicType === type}
+                  first={i === 0}
+                  last={i === row.length - 1}
+                  ariaLabel={label}
+                  onClick={() => {
+                    setPeriodicType(type);
+                    variation.periodicType = type;
+                    block.triggerVariationReactions(uniformName);
+                  }}
+                >
+                  <VStack spacing={0}>
+                    <WaveGlyph type={type} />
+                    <Text fontSize="8px">{label}</Text>
+                  </VStack>
+                </SegmentButton>
+              ))}
+              {/* Keep a short row's segments as wide as those in the row above
+                  rather than stretching them across the full width. */}
+              {Array.from(
+                { length: WAVE_ROWS[0]!.length - row.length },
+                (_, spacerIndex) => (
+                  <Box key={`spacer-${spacerIndex}`} flex={1} />
+                ),
+              )}
+            </HStack>
           ))}
-        </HStack>
+        </VStack>
       </ControlSection>
 
       <ControlSection label="Range">

--- a/src/types/Variations/PeriodicVariation.ts
+++ b/src/types/Variations/PeriodicVariation.ts
@@ -1,7 +1,12 @@
 import { Variation } from "@/src/types/Variations/Variation";
 import type { Store } from "@/src/types/Store";
 
-export type PeriodicVariationType = "sine" | "square" | "triangle";
+export type PeriodicVariationType =
+  | "sine"
+  | "square"
+  | "triangle"
+  | "sawUp"
+  | "sawDown";
 
 export class PeriodicVariation extends Variation<number> {
   displayName = "Periodic";
@@ -74,6 +79,22 @@ export class PeriodicVariation extends Variation<number> {
           this.amplitude +
           this.offset
         );
+      case "sawUp":
+      case "sawDown": {
+        // Ramps across one period then jumps back to where it started: sawUp
+        // goes min -> max, sawDown goes max -> min. Direction lives in the
+        // type rather than in the sign of the amplitude, so min/max stay
+        // ordered (a negative amplitude would invert them and hand
+        // computeDomain a backwards range). Phase is in radians here (as for
+        // sine/square), so a phase of 2*PI advances the ramp by one period.
+        const cyclePosition =
+          (((time / this.period + this.phase / (2 * Math.PI)) % 1) + 1) % 1;
+        const ramp =
+          this.periodicType === "sawUp"
+            ? 2 * cyclePosition - 1
+            : 1 - 2 * cyclePosition;
+        return ramp * this.amplitude + this.offset;
+      }
       default:
         return 0;
     }
@@ -101,7 +122,8 @@ export class PeriodicVariation extends Variation<number> {
   /**
    * Shift the wave as if local t=0 moved later by `dt` seconds — so a mid-cut
    * remnant (or a left-boundary drag) keeps the same continuous waveform.
-   * Sine/square store phase in radians; triangle stores it as a time offset.
+   * Sine/square/saws store phase in radians; triangle stores it as a time
+   * offset.
    */
   shiftStart = (dt: number) => {
     if (this.periodicType === "triangle") this.phase += dt;


### PR DESCRIPTION
Extends periodic LFO variations with sawtooth waveforms, in both directions:

<img width="300" height="263" alt="image" src="https://github.com/user-attachments/assets/2b4c139d-5669-470c-ac2f-55479f280594" />
<img width="230" height="333" alt="image" src="https://github.com/user-attachments/assets/b82d49c7-a0ee-4abe-a083-39ccac860e6a" />


| shape | behavior |
| --- | --- |
| `sawUp` | ramps `min` → `max` across one period, jumps back to `min` |
| `sawDown` | ramps `max` → `min` across one period, jumps back to `max` |

So an LFO can now do `0 → 1 → jump to 0` or `0 → -1 → jump to 0`, at any
amplitude and offset.

### Why direction is a waveform type, not a parameter

A saw is the only shape here where a vertical flip is a genuinely new degree of
freedom — for sine, square, and triangle a flip is just a phase shift, so the
sign of `amplitude` is redundant for them. That new bit has to live somewhere,
and the candidates were: widen `periodicType`, encode it in the sign of
`amplitude`, or add a `sawDirection` field.

Widening `periodicType` won out because it adds no new field (`serialize`,
`deserialize`, and `clone` are untouched), keeps `amplitude` positive so
`min`/`max` stay ordered, and gets exhaustiveness for free — `WAVE_PATHS:
Record<PeriodicVariationType, string>` makes the compiler demand a glyph for
every shape.

Encoding direction in the sign of `amplitude` produces correct values but
inverts the `min`/`max` getters and makes `computeDomain()` return a backwards
range (`[0, -1]`), which is then handed to the graph's recharts `YAxis`. A
`sawDirection` field would need `serialize`/`deserialize`/`clone` updates and
nothing would enforce that it's set for saws.

Phase is interpreted in radians, matching sine/square (triangle is the odd one
out, storing phase as a time offset), so `shiftStart`'s existing radians branch
already keeps a saw continuous through a mid-block cut or a left-boundary drag.

### UI

The waveform picker wraps into rows of three — five segments across the 160px
param panel would leave ~30px each, too narrow for labels like "Triangle" — with
a spacer keeping the second row's two segments the same width as the three
above. Saw glyphs mirror each other.

### Verification

- `yarn typecheck`, `yarn lint`, and prettier all clean.
- 33 numeric assertions against `PeriodicVariation` (throwaway script, not
  committed — this repo has no test setup): both directions start/ramp/wrap
  correctly; arbitrary ranges (`0→1`, `0→-1`, `0→7`, `0→-7`, `2→5`, `5→2`,
  `-3→3`, `0.2→0.8`) keep `min`/`max` ordered with all sampled points in range;
  negative times stay in range; phase `2π` is a no-op; `shiftStart` stays
  continuous; clone and serialize round-trips preserve the type; `sawDown` is the
  exact vertical mirror of `sawUp`; sine/square/triangle values unchanged.
- Ran the dev server and confirmed the picker renders as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
