### PR TITLE
Give each effect its own pipe in the block dot-row, and option-click to close all lanes

### DIFF
--- a/src/components/TimelineBlockStack/BlockDotRow.tsx
+++ b/src/components/TimelineBlockStack/BlockDotRow.tsx
@@ -7,7 +7,7 @@ import { Box, HStack, Text, Tooltip } from "@chakra-ui/react";
 import { action } from "mobx";
 import { observer } from "mobx-react-lite";
 import { MdViewStream } from "react-icons/md";
-import { MouseEvent as ReactMouseEvent, useState } from "react";
+import { Fragment, MouseEvent as ReactMouseEvent, useState } from "react";
 import { hoverHelpProps } from "@/src/utils/hoverHelp";
 
 // params that are machinery rather than user-facing controls
@@ -69,35 +69,40 @@ const gatherSignals = (block: Block) => {
       };
     });
 
-  const effectSignals: Signal[] = block.effectBlocks.flatMap((effectBlock) =>
-    Object.entries(effectBlock.pattern.params)
-      .filter(
-        ([uniformName]) =>
-          !BASE_EXCLUDED.includes(uniformName) && uniformName !== "u_opacity",
-      )
-      .map(([uniformName, patternParam]) => ({
-        block: effectBlock,
-        uniformName,
-        label: `${effectBlock.pattern.name} · ${patternParam.name}`,
-        letter: paramLetter(patternParam.name),
-        authored: isParamAuthored(effectBlock, uniformName),
-        laneOn: effectBlock.lanedParams.has(uniformName),
-        isOpacity: false,
-        fading: false,
-        isPalette: isPalette(patternParam.value),
-        isEffect: true,
-      })),
-  );
+  // one group per effect, in signal order, so each effect's params can sit in
+  // their own pipe-separated cluster
+  const effectGroups: Signal[][] = block.effectBlocks
+    .map((effectBlock) =>
+      Object.entries(effectBlock.pattern.params)
+        .filter(
+          ([uniformName]) =>
+            !BASE_EXCLUDED.includes(uniformName) && uniformName !== "u_opacity",
+        )
+        .map(([uniformName, patternParam]) => ({
+          block: effectBlock,
+          uniformName,
+          label: `${effectBlock.pattern.name} · ${patternParam.name}`,
+          letter: paramLetter(patternParam.name),
+          authored: isParamAuthored(effectBlock, uniformName),
+          laneOn: effectBlock.lanedParams.has(uniformName),
+          isOpacity: false,
+          fading: false,
+          isPalette: isPalette(patternParam.value),
+          isEffect: true,
+        })),
+    )
+    .filter((group) => group.length > 0);
 
-  return { patternSignals, effectSignals };
+  return { patternSignals, effectGroups };
 };
 
 // A glanceable row of per-parameter signals shown beneath a collapsed block's
 // header. Each dot reflects whether its param is authored / at default /
 // crossfading and whether its automation lane is open; clicking a dot toggles
-// that lane. Effect params appear after a divider as diamonds so they never
-// blur into the pattern's own dots. When the block is too narrow to fit the
-// row, it collapses to a summary badge that pops the full row on hover/select.
+// that lane. Each effect's params appear as diamonds in their own divider-
+// separated group, so they never blur into the pattern's own dots or into each
+// other's. When the block is too narrow to fit the row, it collapses to a
+// summary badge that pops the full row on hover/select.
 export const BlockDotRow = observer(function BlockDotRow({
   block,
   isSelected,
@@ -108,14 +113,16 @@ export const BlockDotRow = observer(function BlockDotRow({
   const { uiStore } = useStore();
   const [hovered, setHovered] = useState(false);
 
-  const { patternSignals, effectSignals } = gatherSignals(block);
+  const { patternSignals, effectGroups } = gatherSignals(block);
+  const effectSignals = effectGroups.flat();
   const signalCount = patternSignals.length + effectSignals.length;
   if (signalCount === 0) return null;
 
   const blockWidth = uiStore.timeToX(block.duration);
   const neededWidth =
     signalCount * DOT_FOOTPRINT +
-    (effectSignals.length > 0 ? DOT_FOOTPRINT : 0) +
+    // each effect group is preceded by its own divider
+    effectGroups.length * DOT_FOOTPRINT +
     ROW_PADDING;
   const narrow = blockWidth < neededWidth;
 
@@ -134,7 +141,7 @@ export const BlockDotRow = observer(function BlockDotRow({
           <DotList
             block={block}
             patternSignals={patternSignals}
-            effectSignals={effectSignals}
+            effectGroups={effectGroups}
           />
         </Box>
       </Box>
@@ -192,7 +199,7 @@ export const BlockDotRow = observer(function BlockDotRow({
           <DotList
             block={block}
             patternSignals={patternSignals}
-            effectSignals={effectSignals}
+            effectGroups={effectGroups}
           />
         </Box>
       )}
@@ -203,11 +210,11 @@ export const BlockDotRow = observer(function BlockDotRow({
 const DotList = function DotList({
   block,
   patternSignals,
-  effectSignals,
+  effectGroups,
 }: {
   block: Block;
   patternSignals: Signal[];
-  effectSignals: Signal[];
+  effectGroups: Signal[][];
 }) {
   const { uiStore } = useStore();
   return (
@@ -222,7 +229,7 @@ const DotList = function DotList({
       align="center"
     >
       <Tooltip
-        label="Toggle all lanes"
+        label="Toggle all lanes (⌥ to close all)"
         openDelay={0}
         hasArrow
         placement="top"
@@ -238,40 +245,48 @@ const DotList = function DotList({
           _hover={{ color: "#cbd5e0" }}
           onClick={action((e: ReactMouseEvent) => {
             e.stopPropagation();
-            block.toggleAllLanes();
+            // option/alt-click skips the toggle and always closes everything
+            block.toggleAllLanes(e.altKey);
           })}
           {...hoverHelpProps(
             uiStore,
             "Toggle all lanes",
-            "Arm or disarm automation lanes for every parameter on this block.",
+            "Arm or disarm automation lanes for every parameter on this block. Hold option to close every lane regardless of current state.",
           )}
         >
           <MdViewStream size={13} />
         </Box>
       </Tooltip>
-      <Box
-        flexShrink={0}
-        width="1px"
-        height="14px"
-        bg={DEFAULT_BORDER}
-        mx="1px"
-      />
+      <Divider />
       {patternSignals.map((signal) => (
         <Dot key={signal.uniformName} signal={signal} />
       ))}
-      {effectSignals.length > 0 && (
-        <Box
-          flexShrink={0}
-          width="1px"
-          height="14px"
-          bg={DEFAULT_BORDER}
-          mx="1px"
-        />
-      )}
-      {effectSignals.map((signal) => (
-        <Dot key={`${signal.block.id}:${signal.uniformName}`} signal={signal} />
+      {effectGroups.map((group) => (
+        <Fragment key={group[0].block.id}>
+          <Divider />
+          {group.map((signal) => (
+            <Dot
+              key={`${signal.block.id}:${signal.uniformName}`}
+              signal={signal}
+            />
+          ))}
+        </Fragment>
       ))}
     </HStack>
+  );
+};
+
+// thin vertical rule separating the toggle-all button, the pattern's params,
+// and each effect's params from one another
+const Divider = function Divider() {
+  return (
+    <Box
+      flexShrink={0}
+      width="1px"
+      height="14px"
+      bg={DEFAULT_BORDER}
+      mx="1px"
+    />
   );
 };
 

--- a/src/components/TimelineBlockStack/BlockDotRow.tsx
+++ b/src/components/TimelineBlockStack/BlockDotRow.tsx
@@ -282,7 +282,7 @@ const Divider = function Divider() {
   return (
     <Box
       flexShrink={0}
-      width="1px"
+      width="2px"
       height="14px"
       bg={DEFAULT_BORDER}
       mx="1px"

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -397,14 +397,16 @@ export class Block {
   };
 
   // arms every lanable param across this block and its effect chain, or clears
-  // them all if they are already all armed
-  toggleAllLanes = () => {
+  // them all if they are already all armed. forceClose skips the toggle and
+  // always clears, so a single gesture can close everything.
+  toggleAllLanes = (forceClose = false) => {
     const blocks = [this, ...this.effectBlocks];
     const allArmed = blocks.every((block) =>
       block.lanableParamNames.every((name) => block.lanedParams.has(name)),
     );
+    const arm = forceClose ? false : !allArmed;
     blocks.forEach((block) =>
-      block.setParamLanes(block.lanableParamNames, !allArmed),
+      block.setParamLanes(block.lanableParamNames, arm),
     );
   };
 


### PR DESCRIPTION
# Give each effect its own pipe in the block dot-row, and option-click to close all lanes

Two small quality-of-life changes to the parameter dot-row in the timeline block header.

## Why

**Pipes.** The dot-row separated the pattern's params from its effects' params with a single divider, then ran every effect's params together in one undifferentiated cluster. On a block with two or three effects there was no visual boundary between them, so the diamonds read as one long run and you had to hover each one to work out which effect it belonged to.

**Option-click.** The toggle-all-lanes button flips based on current state: if any lane is closed, clicking arms everything. When you have a few lanes open and just want a clean slate, that means clicking twice — once to open all, once to close all — and watching the timeline balloon in between.

## What changed

- `gatherSignals` now returns `effectGroups: Signal[][]` — one group per effect block, in signal order — instead of a single flattened `effectSignals` array. `DotList` renders a divider before each group, so the row reads `⊞ | pattern | fx1 | fx2 | fx3`. Effects that contribute no lanable params are dropped rather than producing an empty group with a stray divider.
- The repeated divider markup is now a `Divider` component, and it's 2px wide instead of 1px — at 1px it read as a hairline next to the 14px dots.
- The narrow-block collapse threshold budgets one divider per effect group rather than a single one, so blocks with several effects fall back to the summary badge at the right width instead of overflowing.
- `Block.toggleAllLanes` takes a `forceClose` flag that skips the toggle and always disarms. The dot-row button passes `e.altKey`, so option-clicking goes straight to closing every lane. The tooltip and hover-help text mention the modifier.

No behavior change for blocks with zero or one effect, beyond the slightly wider divider.

## Testing

- `tsc --noEmit` and `next lint --dir src` both clean.
- Checked in the running editor on a local experience: pipes appear between each effect's params, dots and lanes still toggle individually, and option-clicking the toggle-all button closes every lane in one gesture.

<img width="448" height="49" alt="image" src="https://github.com/user-attachments/assets/dac07147-9fad-4bb0-b261-66084ee40dd3" />

<img width="172" height="47" alt="image" src="https://github.com/user-attachments/assets/3b161b96-845d-4254-9ede-002d7db23da8" />
