### PR TITLE
Per-block parameter randomization in the pattern playground

### DIFF
--- a/src/components/PatternPlayground/ParameterControls.tsx
+++ b/src/components/PatternPlayground/ParameterControls.tsx
@@ -1,4 +1,4 @@
-import { Button, Heading, VStack } from "@chakra-ui/react";
+import { Button, Heading, Tooltip, VStack } from "@chakra-ui/react";
 import { memo, useState } from "react";
 import { Block } from "@/src/types/Block";
 import { PatternParam } from "@/src/params/shared/patternParam";
@@ -8,26 +8,26 @@ import { randomizeBlockParameters } from "@/src/utils/randomizeBlockParameters";
 
 type ParameterControlsProps = {
   block: Block;
-  // Bumped whenever parameters are randomized (including from a sibling ParameterControls,
-  // e.g. randomizing a pattern also randomizes its applied effects), to remount each
-  // ParameterControl below — they hold local input state that doesn't otherwise react to
-  // param values changing out from under them.
+  // Bumped whenever every block's parameters are randomized at once (see the "Randomize
+  // all" button in PatternPlayground), to remount each ParameterControl below — they hold
+  // local input state that doesn't otherwise react to param values changing out from
+  // under them. Randomizing this block alone bumps a local nonce instead, leaving sibling
+  // blocks' controls untouched.
   randomizeNonce?: number;
-  onRandomize?: () => void;
 };
 
 export const ParameterControls = memo(function ParameterControls({
   block,
   randomizeNonce = 0,
-  onRandomize,
 }: ParameterControlsProps) {
   const [showControls, toggleControls] = useState(true);
+  const [blockRandomizeNonce, setBlockRandomizeNonce] = useState(0);
 
   const isEffect = block.parentBlock !== null;
 
   const onRandomizeClick = () => {
-    randomizeBlockParameters(block);
-    onRandomize?.();
+    randomizeBlockParameters(block, { includeEffectBlocks: false });
+    setBlockRandomizeNonce((n) => n + 1);
   };
 
   return (
@@ -47,18 +47,21 @@ export const ParameterControls = memo(function ParameterControls({
         >
           {showControls ? <BsArrowsCollapse /> : <BsArrowsExpand />}
         </Button>
-        {!isEffect && (
+        <Tooltip
+          label={`Randomize only this ${isEffect ? "effect" : "pattern"}'s parameters`}
+          openDelay={500}
+        >
           <Button size="xs" ml={2} onClick={onRandomizeClick}>
             Randomize
           </Button>
-        )}
+        </Tooltip>
       </Heading>
 
       {showControls &&
         Object.entries<PatternParam>(block.pattern.params).map(
           ([uniformName, patternParam]) => (
             <ParameterControl
-              key={`${uniformName}-${randomizeNonce}`}
+              key={`${uniformName}-${randomizeNonce}-${blockRandomizeNonce}`}
               block={block}
               uniformName={uniformName}
               patternParam={patternParam}

--- a/src/components/PatternPlayground/PatternPlayground.tsx
+++ b/src/components/PatternPlayground/PatternPlayground.tsx
@@ -1,4 +1,11 @@
-import { Box, Button, HStack, useToast, VStack } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  HStack,
+  Tooltip,
+  useToast,
+  VStack,
+} from "@chakra-ui/react";
 import { PatternList } from "@/src/components/PatternPlayground/PatternList";
 import { PreviewCanvas } from "@/src/components/Canvas/PreviewCanvas";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -9,6 +16,7 @@ import { action, runInAction } from "mobx";
 import { SendDataButton } from "@/src/components/SendDataButton";
 import { VJDisplayModeButtons } from "@/src/components/VJPage/VJDisplayModeButtons";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { randomizeBlockParameters } from "@/src/utils/randomizeBlockParameters";
 // import { RecordCanvasControls } from "@/src/components/PatternPlayground/RecordCanvasControls";
 
 export const PatternPlayground = observer(function PatternPlayground() {
@@ -25,12 +33,17 @@ export const PatternPlayground = observer(function PatternPlayground() {
     selectedPatternBlock,
   } = playgroundStore;
 
-  // Bumped whenever parameters are randomized, so both the pattern's and its applied
-  // effects' ParameterControls remount together and pick up the new values.
+  // Bumped whenever every block's parameters are randomized at once, so both the
+  // pattern's and its applied effects' ParameterControls remount together and pick up the
+  // new values. Randomizing a single block is handled within its own ParameterControls.
   // Combined with playgroundStore.controlsNonce (external loads, e.g. from timeline).
   const [randomizeNonce, setRandomizeNonce] = useState(0);
-  const onRandomize = useCallback(() => setRandomizeNonce((n) => n + 1), []);
   const controlsNonce = randomizeNonce + playgroundStore.controlsNonce;
+
+  const onRandomizeAll = useCallback(() => {
+    randomizeBlockParameters(selectedPatternBlock);
+    setRandomizeNonce((n) => n + 1);
+  }, [selectedPatternBlock]);
 
   const applyPatternEffects = useCallback(
     (patternIndex: number, effectIndices: number[]) => {
@@ -182,13 +195,21 @@ export const PatternPlayground = observer(function PatternPlayground() {
           <PanelResizeHandle />
           <Panel defaultSize={50}>
             <VStack key={playgroundStore.id} height="100%" width="100%">
-              <VStack mt={10}></VStack>
+              <HStack height={10} width="100%" justify="center" flexShrink={0}>
+                <Tooltip
+                  label="Randomize parameters for the pattern and every effect applied to it"
+                  openDelay={500}
+                >
+                  <Button size="xs" onClick={onRandomizeAll}>
+                    Randomize all
+                  </Button>
+                </Tooltip>
+              </HStack>
               <VStack width="100%" overflowY="auto">
                 <ParameterControls
                   key={selectedPatternBlock.id}
                   block={selectedPatternBlock}
                   randomizeNonce={controlsNonce}
-                  onRandomize={onRandomize}
                 />
                 {selectedEffectIndices.map((effectIndex, i) => (
                   <ParameterControls

--- a/src/params/palette/ParameterControl.tsx
+++ b/src/params/palette/ParameterControl.tsx
@@ -1,5 +1,6 @@
 import { HStack } from "@chakra-ui/react";
-import { memo, useCallback, useEffect } from "react";
+import { useCallback, useEffect } from "react";
+import { observer } from "mobx-react-lite";
 import { Block } from "@/src/types/Block";
 import { ParamType, PatternParam } from "@/src/params/shared/patternParam";
 import { DEFAULT_VARIATION_DURATION } from "@/src/utils/time";
@@ -15,48 +16,54 @@ type PaletteParameterControlProps = {
   patternParam: PatternParam<Palette>;
 };
 
-export const PaletteParameterControl = memo(function PaletteParameterControl({
-  block,
-  uniformName,
-  patternParam,
-}: PaletteParameterControlProps) {
-  const updatePaletteVariation = useCallback(() => {
-    runInAction(() => {
-      if (!block.parameterVariations[uniformName])
-        block.parameterVariations[uniformName] = [];
+// observer, not memo: the render body reads the observable
+// block.parameterVariations, and the variation is only created in an effect
+// after first mount. Without reactivity that mutation never re-renders, so the
+// editor stays hidden and the row renders as a bare label.
+export const PaletteParameterControl = observer(
+  function PaletteParameterControl({
+    block,
+    uniformName,
+    patternParam,
+  }: PaletteParameterControlProps) {
+    const updatePaletteVariation = useCallback(() => {
+      runInAction(() => {
+        if (!block.parameterVariations[uniformName])
+          block.parameterVariations[uniformName] = [];
 
-      block.parameterVariations[uniformName]![0] = new PaletteVariation(
-        DEFAULT_VARIATION_DURATION,
-        patternParam.value,
-      );
-    });
-  }, [block.parameterVariations, patternParam.value, uniformName]);
+        block.parameterVariations[uniformName]![0] = new PaletteVariation(
+          DEFAULT_VARIATION_DURATION,
+          patternParam.value,
+        );
+      });
+    }, [block.parameterVariations, patternParam.value, uniformName]);
 
-  const variation = block.parameterVariations[uniformName]?.[0];
+    const variation = block.parameterVariations[uniformName]?.[0];
 
-  useEffect(() => {
-    if (!variation) {
+    useEffect(() => {
+      if (!variation) {
+        updatePaletteVariation();
+      }
+    }, [block.id, uniformName, variation, updatePaletteVariation]);
+
+    const setParameter = (value: Palette) => {
+      block.pattern.params[uniformName].value = value;
       updatePaletteVariation();
-    }
-  }, [block.id, uniformName, variation, updatePaletteVariation]);
+    };
 
-  const setParameter = (value: Palette) => {
-    block.pattern.params[uniformName].value = value;
-    updatePaletteVariation();
-  };
-
-  return (
-    <HStack width="100%" gap={4}>
-      <ParameterControlName patternParam={patternParam} />
-      {variation?.type === "palette" && (
-        <PaletteEditor
-          uniformName={uniformName}
-          // TODO: do better type discrimination
-          variation={variation as PaletteVariation}
-          block={block}
-          setPalette={(palette) => setParameter(palette)}
-        />
-      )}
-    </HStack>
-  );
-});
+    return (
+      <HStack width="100%" gap={4}>
+        <ParameterControlName patternParam={patternParam} />
+        {variation?.type === "palette" && (
+          <PaletteEditor
+            uniformName={uniformName}
+            // TODO: do better type discrimination
+            variation={variation as PaletteVariation}
+            block={block}
+            setPalette={(palette) => setParameter(palette)}
+          />
+        )}
+      </HStack>
+    );
+  },
+);

--- a/src/utils/randomizeBlockParameters.ts
+++ b/src/utils/randomizeBlockParameters.ts
@@ -64,15 +64,29 @@ function randomizeParams(block: Block): void {
   }
 }
 
+type RandomizeBlockParametersOptions = {
+  /**
+   * When true (the default), also randomizes the parameters of every effect block
+   * currently applied to `block`. Pass false to randomize only `block` itself.
+   */
+  includeEffectBlocks?: boolean;
+};
+
 /**
- * Randomizes every parameter on a pattern block (and any effect blocks currently
- * applied to it) in place, keeping `parameterVariations` in sync the same way each
- * param type's own control does (see {@link setBlockNumberParameterValue},
- * `ColorParameterControl`, `Palette.randomize`).
+ * Randomizes every parameter on a block in place, keeping `parameterVariations` in
+ * sync the same way each param type's own control does (see
+ * {@link setBlockNumberParameterValue}, `ColorParameterControl`,
+ * `Palette.randomize`).
+ *
+ * By default this also randomizes any effect blocks applied to `block`; pass
+ * `{ includeEffectBlocks: false }` to scope the randomization to `block` alone.
  */
-export function randomizeBlockParameters(block: Block): void {
+export function randomizeBlockParameters(
+  block: Block,
+  { includeEffectBlocks = true }: RandomizeBlockParametersOptions = {},
+): void {
   runInAction(() => {
     randomizeParams(block);
-    block.effectBlocks.forEach(randomizeParams);
+    if (includeEffectBlocks) block.effectBlocks.forEach(randomizeParams);
   });
 }


### PR DESCRIPTION
## Why

The playground's `Randomize` button randomizes the selected pattern *and* every effect applied to it. That's useful, but it lives in the pattern block's header, where it reads as "randomize this pattern" — and there was no way to reroll a single block. If you liked the pattern and only wanted to shake up one effect, your only option was to randomize everything and hope.

## What

**Per-block randomization.** Every block in the parameter panel — the pattern and each applied effect — now has its own `Randomize` button that touches only that block's parameters.

**The all-at-once behavior is unchanged, but moves.** It's now a `Randomize all` button in a band above the parameter panel, out of the pattern header where its scope was misleading. It occupies the empty spacer that was already there, so nothing shifts down.

Both buttons have tooltips spelling out their scope.

### Implementation notes

- `randomizeBlockParameters` takes an `{ includeEffectBlocks }` option. Per-block randomization passes `false`; `Randomize all` keeps the default `true`, so its behavior is byte-for-byte what it was.
- The parameter controls hold local input state and have to be remounted when values change underneath them. Single-block randomization now bumps a nonce local to that `ParameterControls`, so randomizing one effect no longer discards in-progress edits in a sibling block. The shared nonce still drives `Randomize all` and external block loads (`playgroundStore.controlsNonce`).

When no effects are applied, `Randomize all` and the pattern's own `Randomize` do the same thing. I left both visible — a button that vanishes depending on effect count seemed more confusing than a redundant one.

## Also: palette parameters rendered collapsed in the playground

Separate bug, folded in here because it's in the same panel and the remount behavior above makes it much easier to hit.

Palette parameters rendered as a bare `Palette` label — no swatch, no gradient, no presets — so there was no way to reach the value at all.

`PaletteParameterControl` reads the observable `block.parameterVariations` in its render body, but was wrapped in `memo()` rather than `observer()`. On first paint that read returns `undefined`, so the `PaletteEditor` stays behind its `variation?.type === "palette"` guard. The variation is then created in a `useEffect` — but a plain `memo` component isn't subscribed to that MobX mutation, so no re-render fires and the row stays a stub until something unrelated knocks it loose.

Swapping `memo` for `observer` fixes it. The VJ palette control (`VJParameterControl.tsx`) has the identical structure and was already an `observer`, which is why it never showed the bug; a comment now records why the wrapper matters, since the two controls sitting side by side with different wrappers is what let this drift in.

Worth noting the interaction with the change above: remounting a `ParameterControls` via the nonce puts every control back at first paint, so pre-fix, each randomize re-collapsed the palette rows.

## Testing

`tsc --noEmit`, `next lint --dir src`, and `prettier --check` are clean.

For the randomize buttons: ran a dev server and confirmed `/playground` compiles and serves without errors; the button placement itself is worth a quick look in the browser, since the page is client-rendered and I couldn't assert on the DOM.

For the palette fix: captured the playground before and after the one-line change on an otherwise identical dev server. Before, the palette row is a bare label; after, the gradient bar, `Gradient` from/to swatches, the nine-preset grid, and the `Advanced` disclosure all render on first paint. Re-confirmed on this branch with both commits applied, so the nonce remounts and the fix coexist.

<img width="670" height="156" alt="image" src="https://github.com/user-attachments/assets/b2fd91f3-08b0-4da9-aeb4-b97eb3dbbc62" />

<img width="1013" height="457" alt="image" src="https://github.com/user-attachments/assets/5ab55b06-dfd7-4894-9e87-d12a7f69fa97" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
