### PR TITLE
Fix Barcode2 mirror toggle and palette coverage

### DIFF
--- a/src/patterns/Barcode2.ts
+++ b/src/patterns/Barcode2.ts
@@ -77,6 +77,7 @@ export const Barcode2 = () =>
       min: -50,
       max: 50,
     },
+    // 1 means no mirroring; 2 and up fold the canopy into that many wedges
     u_mirrorCount: {
       name: "Mirror Count",
       value: 8,

--- a/src/patterns/shaders/barcode2.frag
+++ b/src/patterns/shaders/barcode2.frag
@@ -35,7 +35,13 @@ uniform float u_angle;
 // #define u_angle 0.
 
 // Same fold as the Mirror effect: remap UV into a mirrored kaleidoscope wedge.
+// A count of 1 means no mirroring, so return p untouched rather than folding —
+// the atan/cos/sin round trip below is only an identity in exact arithmetic, and
+// rounding it would shift cell boundaries. The 1.5 cutoff matches the
+// round-to-nearest that picks n, so a count rounding to 1 is off and 2 folds.
 vec2 mirrorFold(vec2 p) {
+    if (u_mirrorCount < 1.5) return p;
+
     float axis = u_angle * PI + 0.5 * PI;
     p = rotate2DCentered(p, -axis);
 

--- a/src/patterns/shaders/barcode2.frag
+++ b/src/patterns/shaders/barcode2.frag
@@ -34,6 +34,10 @@ uniform float u_angle;
 // #define u_mirrorCount 2.
 // #define u_angle 0.
 
+// Decorrelates the lit/unlit draw from the color draw. Any value that shifts
+// the hash input works; this one just needs to stay away from the seed range.
+#define LIT_OFFSET 17.0
+
 // Same fold as the Mirror effect: remap UV into a mirrored kaleidoscope wedge.
 // A count of 1 means no mirroring, so return p untouched rather than folding —
 // the atan/cos/sin round trip below is only an identity in exact arithmetic, and
@@ -89,8 +93,12 @@ void main() {
     vec2 ipos = floor(vec2(mod(st.x, u_bars), mod(st.y, u_bars)));  // integer
     vec2 fpos = fract(st);  // fraction
 
-    float intensityA = step(1. - u_bar_likelihood, rand(ipos + seedA));
-    float intensityB = step(1. - u_bar_likelihood, rand(ipos + seedB));
+    // Draw lit/unlit from a different offset than the color below. Sharing one
+    // draw would mean a bar is lit exactly when its palette lookup is high, so
+    // only the top u_bar_likelihood slice of the gradient could ever be seen.
+    // Barcode gets this separation for free by seeding intensity with timeCell.
+    float intensityA = step(1. - u_bar_likelihood, rand(ipos + seedA + LIT_OFFSET));
+    float intensityB = step(1. - u_bar_likelihood, rand(ipos + seedB + LIT_OFFSET));
     float intensity = mix(intensityA, intensityB, seedT);
     intensity *= 1. - u_bar_fade_factor * abs((fpos.x - 0.5) * 2.0);
 


### PR DESCRIPTION
Two Barcode2 fixes.

**Mirror Count of 1 didn't turn mirroring off.** The slider goes down to 1, but the code clamped it to 2, so you always got a mirror. Now 1 means off.

**Most of the palette never showed up.** Each bar used one random number to decide both whether it was lit and what color it was. So the only bars you ever saw were the ones whose color came from the top of the gradient — at the default Bar Likelihood, the top quarter of it. They use separate numbers now, so the whole palette shows.

The palette fix visibly changes how Barcode2 looks. Nothing saved uses Barcode2 — checked all 57 experiences and 7 VJ presets in prod — so no existing work is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)