### PR TITLE
Add a Time Offset parameter to the Perlin patterns

### DIFF
--- a/src/patterns/Perlin.ts
+++ b/src/patterns/Perlin.ts
@@ -13,6 +13,12 @@ export const Perlin = () =>
       name: "Time Factor",
       value: 0.5,
     },
+    u_timeOffset: {
+      name: "Time Offset",
+      value: 0,
+      min: -5,
+      max: 5,
+    },
     u_colorShift: {
       name: "Color Shift",
       value: 0.5,

--- a/src/patterns/Perlin2.ts
+++ b/src/patterns/Perlin2.ts
@@ -13,6 +13,12 @@ export const Perlin2 = () =>
       name: "Time Factor",
       value: 0.5,
     },
+    u_timeOffset: {
+      name: "Time Offset",
+      value: 0,
+      min: -5,
+      max: 5,
+    },
     u_colorShift: {
       name: "Color Shift",
       value: 0.5,

--- a/src/patterns/shaders/perlin.frag
+++ b/src/patterns/shaders/perlin.frag
@@ -8,6 +8,7 @@ varying vec2 v_uv;
 uniform float u_time;
 
 uniform float u_timeFactor;
+uniform float u_timeOffset;
 uniform float u_colorShift;
 uniform float u_seed;
 uniform float u_steps;
@@ -165,7 +166,9 @@ void main() {
   vec2 uv = v_uv;
   vec2 pos = vec2(uv * u_period);
 
-  float n = cnoise(vec4(pos, u_time * u_timeFactor, u_seed));
+  float t = u_time * u_timeFactor + u_timeOffset;
+
+  float n = cnoise(vec4(pos, t, u_seed));
   vec3 col = n > 0. ? palette(n + u_time * u_colorShift, u_palette) : vec3(0.);
 
   for (float i = 0.; i < u_steps; i ++) {

--- a/src/patterns/shaders/perlin2.frag
+++ b/src/patterns/shaders/perlin2.frag
@@ -8,6 +8,7 @@ varying vec2 v_uv;
 uniform float u_time;
 
 uniform float u_timeFactor;
+uniform float u_timeOffset;
 uniform float u_colorShift;
 uniform float u_seed;
 uniform float u_steps;
@@ -164,7 +165,7 @@ float cnoise(vec4 P) {
 void main() {
   vec2 uv = v_uv;
   vec2 pos = vec2(uv * u_period);
-  float t = u_time * u_timeFactor;
+  float t = u_time * u_timeFactor + u_timeOffset;
 
   float n = cnoise(vec4(pos, t, u_seed));
   vec3 col = n > 0. ? palette(n + t * u_colorShift, u_palette) : vec3(0.);


### PR DESCRIPTION
Perlin and Perlin2 had no way to shift where in their animation they start, so two blocks of the same pattern always moved in lockstep. This adds a Time Offset param to both, following the convention the other patterns already use (Melt, Fire, Rainbow, Starfield, Tunnel): `time = u_time * timeFactor + timeOffset`, range -5 to 5.

It defaults to 0, which leaves rendering exactly as it was. Saved experiences are unaffected — they simply have no `u_timeOffset` entry and fall back to the default of 0.

One thing worth knowing: in Perlin2 the offset also shifts the palette phase, because that shader already derives its color from the same time value. In Perlin the color shift is driven by raw `u_time` and I left it that way, since following each shader's existing structure is what kept the offset-0 output identical.