### PR TITLE
Fix Log Spirals flickering between 4 and 3 arms

### DIFF
--- a/src/types/Variations/CurveVariation.ts
+++ b/src/types/Variations/CurveVariation.ts
@@ -174,6 +174,15 @@ export class CurveVariation extends Variation<number> {
       const b = nodes[i + 1];
       if (a.time <= time && time < b.time) {
         const [p0, p1, p2, p3] = this.segmentControlPoints(i);
+        // A segment whose four control values are equal IS that constant, so
+        // return it exactly. evalCubic evaluates the Bernstein basis directly,
+        // and t^3 + 3t^2*s + 3t*s^2 + s^3 does not sum to exactly 1 in floating
+        // point, so a flat region otherwise yields value +/- 1 ulp for ~32% of
+        // times. That is invisible on a float uniform, but int uniforms are
+        // uploaded with gl.uniform1i, which TRUNCATES: 3.9999999999999996
+        // reaches the shader as 3. It flipped Log Spirals between 4 and 3 arms
+        // every few frames (u_spiralCount / u_colorIterations are `uniform int`).
+        if (p0.v === p1.v && p1.v === p2.v && p2.v === p3.v) return p0.v;
         return bezierValueAtX(
           p0.t,
           p0.v,


### PR DESCRIPTION
Log Spirals has been visibly flickering in production — the number of spiral arms jumps between 4 and 3 several times a second. It turned out not to be the shader or the audio clock.

Parameters that hold a constant value are still evaluated through a curve every frame, using the standard cubic formula. Mathematically that formula returns the constant exactly. In floating-point arithmetic it doesn't quite: about a third of the time it comes back a hair off, so a parameter set to 4 evaluates to 3.9999999999999996.

For most parameters that's harmless — a difference that small can't change what you see. But some parameters are whole numbers by nature, like "how many spiral arms," and when WebGL hands those to the graphics card it chops off the decimal rather than rounding. So 3.9999999999999996 arrives as **3**. Since that one value controls the arm count, their spacing, and their colour all at once, a single flip rearranges the entire pattern.

The fix: when a curve segment is flat, return its value directly instead of computing it. Every other segment goes through the same code as before and is completely unaffected.

**Verification.** To confirm nothing else moved, I rendered all 17 production experiences twice — once on `main`, once with this change — sampling a frame every two seconds across each one (~2,276 frames per version) and compared them pixel by pixel. Rendering the same version twice gave identical frames, so any difference is a real one. Between `main` and this change, 2,203 frames matched and 73 differed — and all 73 are inside Log Spirals or GalaxyTour blocks, the only two patterns with whole-number parameters. Nothing outside those blocks changed.

**Six experiences will look different, which is the point** — they stop flickering: `beetleking`, `wandersail`, `ff7`, `for-the-uncles-and-aunties`, `queen-of-all-everything`, `penumbra`. Log Spirals blocks get their intended arm count back, and `penumbra`'s GalaxyTour stops dropping its stars in and out. `cosmos` and `zhu-only` also use GalaxyTour but were unaffected and render identically.

**Not fixed here:** `ff7` deliberately ramps its arm count from 4 down to 1, and mid-ramp the value genuinely lands between whole numbers. That still rounds down, same as before — it's existing behaviour and arguably correct, so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)