### PR TITLE
Add mask-only twist parameter to Shape Mask

### DIFF
--- a/src/effects/ShapeMask.ts
+++ b/src/effects/ShapeMask.ts
@@ -44,6 +44,16 @@ export const ShapeMask = () =>
         value: 0,
         step: 1,
       },
+      // Twists the mask's own angular coordinate (proportional to radius),
+      // independent of the Twist pattern -- that one distorts the sampled
+      // image itself, this only distorts where the mask boundary falls.
+      // 0 = no twist, matching legacy behavior for existing experiences.
+      u_mask_twist: {
+        name: "Twist",
+        value: 0,
+        min: -2,
+        max: 2,
+      },
     },
     ["v_uv", "v_normalized_uv"],
   );

--- a/src/effects/shaders/shapeMask.frag
+++ b/src/effects/shaders/shapeMask.frag
@@ -13,6 +13,7 @@ uniform float u_radius;
 uniform float u_theta_min;
 uniform float u_theta_max;
 uniform float u_inverse;
+uniform float u_mask_twist;
 
 // // For debugging
 // #define u_inner_radius 0.0
@@ -20,12 +21,18 @@ uniform float u_inverse;
 // #define u_theta_min 0.0
 // #define u_theta_max 360.0
 // #define u_inverse 0.0
+// #define u_mask_twist 0.0
 
 void main() {
     vec2 st = v_uv;
     st = cartesianToCanopyProjection(st);
     // In canopy coordinates: st.y is the radial distance (0 = apex, 1 = outer
     // edge) and st.x is the angle around the center, normalized to 0..1.
+
+    // Twist the MASK's own angular coordinate, proportional to radius --
+    // distinct from the Twist pattern, which resamples the image itself.
+    // Default 0 is a no-op (fract of an already-wrapped value).
+    st.x = fract(st.x + u_mask_twist * st.y);
 
     // Radial band: keep pixels between the inner and outer radius. The default
     // inner radius of 0 keeps the full inner disc, matching legacy behavior


### PR DESCRIPTION
## Summary
- Adds a `Twist` parameter to the Shape Mask effect that twists the mask's own angular coordinate (proportional to radius), independent of the existing Twist pattern which resamples the whole image
- Default value of 0 is a no-op, so existing experiences using Shape Mask render unchanged

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Manual click-test in the browser (add Shape Mask to a pattern block, adjust Twist, confirm mask boundary spirals while default 0 stays identical to before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)