### PR TITLE
Sort user list alphabetically in login overlay

### DIFF
--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -96,6 +96,7 @@ export const LoginButton = observer(function LoginButton() {
               {!isPending &&
                 (users ?? [])
                   .filter((user) => user.username !== userStore.username)
+                  .sort((a, b) => a.username.localeCompare(b.username))
                   .map((user) => (
                     <Button
                       key={user.id}


### PR DESCRIPTION
The user picker in the login overlay showed names in raw DB order (insertion order), making it harder to find a name as the user list grows. Now sorted alphabetically by username.

## Test plan
- [ ] Open the login overlay and confirm names appear alphabetically