### PR TITLE
Fix smoothing not saving on audio variations

### DIFF
--- a/src/types/Variations/AudioVariation.ts
+++ b/src/types/Variations/AudioVariation.ts
@@ -58,6 +58,7 @@ export class AudioVariation extends Variation<number> {
     duration: this.duration,
     factor: this.factor,
     offset: this.offset,
+    smoothing: this.smoothing,
   });
 
   static deserialize = (store: Store, data: any) =>


### PR DESCRIPTION
Smoothing on an audio region wasn't surviving a save and reload — it always came back as 0.

The save path simply wasn't writing the field out. Reading it back then fell through to a default of 0, so the value looked like it had never been set. Applies to audio regions and block parameters alike. One-line fix.

Worth knowing: experiences saved before this will still load with smoothing at 0, since the value was never stored in the first place. Setting it once more and saving will make it stick from then on.