### PR TITLE
Add layer and global effects

### DIFF
--- a/src/components/ExperienceEditor/BlockDevicePanel.tsx
+++ b/src/components/ExperienceEditor/BlockDevicePanel.tsx
@@ -1,4 +1,6 @@
 import { Block } from "@/src/types/Block";
+import { EffectChain } from "@/src/types/EffectChain";
+import type { Pattern } from "@/src/types/Pattern";
 import { isPalette, Palette } from "@/src/params/palette/Palette";
 import { playgroundEffects } from "@/src/effects/effects";
 import { paramValueAtTime } from "@/src/utils/paramValueAtTime";
@@ -55,6 +57,13 @@ const selectedPatternBlock = (
   return null;
 };
 
+// The chain a block belongs to when it processes composited output rather than
+// living on a pattern block; null for ordinary pattern blocks.
+const owningEffectChain = (block: Block): EffectChain | null =>
+  block.inEffectChain && block.layer instanceof EffectChain
+    ? block.layer
+    : null;
+
 const paletteToGradient = (palette: Palette): string => {
   const stops = [0, 0.2, 0.4, 0.6, 0.8, 1].map((t) => {
     const c = palette.colorAt(t);
@@ -66,30 +75,42 @@ const paletteToGradient = (palette: Palette): string => {
 };
 
 // 4a device panel — a fixed-height bottom panel (Ableton Device View) showing
-// the selected pattern block's chain: the pattern and its effects as
-// left-to-right units in signal order. It is the roster + effect-chain home;
-// motion is still authored on the timeline lanes. Arming a param (◉) opens its
-// lane in the timeline (drives block.lanedParams).
+// the selected block's chain: a source and its effects as left-to-right units
+// in signal order. For a pattern block the source is the pattern; for a block in
+// a layer's or the experience's effect chain it is that chain's composited
+// input, and the units are the whole chain. It is the roster + effect-chain
+// home; motion is still authored on the timeline lanes. Arming a param (◉)
+// opens its lane in the timeline (drives block.lanedParams).
 export const BlockDevicePanel = observer(function BlockDevicePanel() {
   const store = useStore();
   const block = selectedPatternBlock(store);
   if (!block) return null;
 
+  const chain = owningEffectChain(block);
+
   // Read the observable array in the component's own (tracked) render so the
   // observer re-renders on add/remove/reorder — reading it only inside the
   // Droppable render-prop below would happen outside this component's tracking.
-  const effectBlocks = [...block.effectBlocks];
+  const effectBlocks = chain ? [...chain.blocks] : [...block.effectBlocks];
   const reorderable = effectBlocks.length >= 2;
   const { uiStore } = store;
 
+  const reorderEffect = (effectBlock: Block, delta: number) =>
+    chain
+      ? chain.reorderBlock(effectBlock, delta)
+      : block.reorderEffectBlock(effectBlock, delta);
+  const removeEffect = (effectBlock: Block) =>
+    chain
+      ? chain.removeBlock(effectBlock)
+      : block.removeEffectBlock(effectBlock);
+  const addEffect = (effect: Pattern) =>
+    chain ? chain.addCloneOfEffect(effect) : block.addCloneOfEffect(effect);
+
   const onDragEnd: OnDragEndResponder = action((result) => {
     if (!result.destination) return;
-    const effectBlock = block.effectBlocks[result.source.index];
+    const effectBlock = effectBlocks[result.source.index];
     if (!effectBlock) return;
-    block.reorderEffectBlock(
-      effectBlock,
-      result.destination.index - result.source.index,
-    );
+    reorderEffect(effectBlock, result.destination.index - result.source.index);
   });
 
   return (
@@ -125,10 +146,14 @@ export const BlockDevicePanel = observer(function BlockDevicePanel() {
       <Box flex="1" minH={0} overflowX="auto" overflowY="hidden">
         <DragDropContext onDragEnd={onDragEnd}>
           <HStack align="stretch" spacing={0} minW="min-content" height="100%">
-            <PatternUnit block={block} />
+            {chain ? (
+              <ChainSourceUnit chain={chain} />
+            ) : (
+              <PatternUnit block={block} />
+            )}
             <Connector />
             <Droppable
-              droppableId={`device-${block.id}`}
+              droppableId={`device-${chain?.id ?? block.id}`}
               direction="horizontal"
             >
               {(provided) => (
@@ -154,8 +179,9 @@ export const BlockDevicePanel = observer(function BlockDevicePanel() {
                         >
                           {index > 0 && <Connector />}
                           <EffectUnit
-                            parentBlock={block}
                             effectBlock={effectBlock}
+                            onRemove={() => removeEffect(effectBlock)}
+                            isSelected={chain ? effectBlock === block : false}
                             dragHandleProps={
                               reorderable ? prov.dragHandleProps : undefined
                             }
@@ -168,7 +194,14 @@ export const BlockDevicePanel = observer(function BlockDevicePanel() {
                 </HStack>
               )}
             </Droppable>
-            <AddEffectUnit block={block} />
+            <AddEffectUnit
+              onAddEffect={addEffect}
+              helpDescription={
+                chain
+                  ? "Append an effect to this chain, applied to its composited input."
+                  : "Append an effect to this pattern's processing chain."
+              }
+            />
           </HStack>
         </DragDropContext>
       </Box>
@@ -448,12 +481,14 @@ const PanelIconButton = function PanelIconButton({
 };
 
 const EffectUnit = function EffectUnit({
-  parentBlock,
   effectBlock,
+  onRemove,
+  isSelected,
   dragHandleProps,
 }: {
-  parentBlock: Block;
   effectBlock: Block;
+  onRemove: () => void;
+  isSelected: boolean;
   dragHandleProps: any;
 }) {
   const { uiStore } = useStore();
@@ -466,7 +501,7 @@ const EffectUnit = function EffectUnit({
       display="flex"
       flexDirection="column"
       bg="#1b212b"
-      border="1px solid #2f3a48"
+      border={`1px solid ${isSelected ? "#3182ce" : "#2f3a48"}`}
       borderRadius="4px"
       px={1.5}
       py={1}
@@ -509,11 +544,11 @@ const EffectUnit = function EffectUnit({
               cursor="pointer"
               flexShrink={0}
               _hover={{ color: "#fc8181" }}
-              onClick={action(() => parentBlock.removeEffectBlock(effectBlock))}
+              onClick={action(onRemove)}
               {...hoverHelpProps(
                 uiStore,
                 "Remove effect",
-                "Detach this effect from the pattern's effect chain.",
+                "Detach this effect from the chain.",
               )}
             >
               <TbTrash size={12} />
@@ -526,7 +561,43 @@ const EffectUnit = function EffectUnit({
   );
 };
 
-const AddEffectUnit = function AddEffectUnit({ block }: { block: Block }) {
+// Stands in for the pattern at the head of a post-composite chain: what the
+// chain processes is the output of a layer or of the whole layer stack.
+const ChainSourceUnit = function ChainSourceUnit({
+  chain,
+}: {
+  chain: EffectChain;
+}) {
+  return (
+    <Box
+      flexShrink={0}
+      display="flex"
+      flexDirection="column"
+      justifyContent="center"
+      bg="#1e2635"
+      border="1px solid #3a4658"
+      borderRadius="4px"
+      px={2}
+      py={1}
+      maxW="140px"
+    >
+      <Text fontSize="11px" fontWeight={600} color="#63b3ed" noOfLines={1}>
+        {chain.name}
+      </Text>
+      <Text fontSize="9.5px" color="#718096" noOfLines={2}>
+        composited input
+      </Text>
+    </Box>
+  );
+};
+
+const AddEffectUnit = function AddEffectUnit({
+  onAddEffect,
+  helpDescription,
+}: {
+  onAddEffect: (effect: Pattern) => void;
+  helpDescription: string;
+}) {
   const { uiStore } = useStore();
   return (
     <Menu placement="top">
@@ -542,11 +613,7 @@ const AddEffectUnit = function AddEffectUnit({ block }: { block: Block }) {
         color="#718096"
         fontSize="20px"
         fontWeight={400}
-        {...hoverHelpProps(
-          uiStore,
-          "Add effect",
-          "Append an effect to this pattern's processing chain.",
-        )}
+        {...hoverHelpProps(uiStore, "Add effect", helpDescription)}
       >
         ＋
       </MenuButton>
@@ -559,7 +626,7 @@ const AddEffectUnit = function AddEffectUnit({ block }: { block: Block }) {
           {playgroundEffects.map((effect) => (
             <MenuItem
               key={effect.name}
-              onClick={action(() => block.addCloneOfEffect(effect))}
+              onClick={action(() => onAddEffect(effect))}
             >
               {effect.name}
             </MenuItem>

--- a/src/components/ExperienceEditor/BlockDevicePanel.tsx
+++ b/src/components/ExperienceEditor/BlockDevicePanel.tsx
@@ -76,11 +76,11 @@ const paletteToGradient = (palette: Palette): string => {
 
 // 4a device panel — a fixed-height bottom panel (Ableton Device View) showing
 // the selected block's chain: a source and its effects as left-to-right units
-// in signal order. For a pattern block the source is the pattern; for a block in
-// a layer's or the experience's effect chain it is that chain's composited
-// input, and the units are the whole chain. It is the roster + effect-chain
-// home; motion is still authored on the timeline lanes. Arming a param (◉)
-// opens its lane in the timeline (drives block.lanedParams).
+// in signal order. For a pattern block the source is the pattern; for a chain
+// block it is the composited input the chain is handed. Either way the units
+// after it are that block's own effects. It is the roster + effect-chain home;
+// motion is still authored on the timeline lanes. Arming a param (◉) opens its
+// lane in the timeline (drives block.lanedParams).
 export const BlockDevicePanel = observer(function BlockDevicePanel() {
   const store = useStore();
   const block = selectedPatternBlock(store);
@@ -91,26 +91,18 @@ export const BlockDevicePanel = observer(function BlockDevicePanel() {
   // Read the observable array in the component's own (tracked) render so the
   // observer re-renders on add/remove/reorder — reading it only inside the
   // Droppable render-prop below would happen outside this component's tracking.
-  const effectBlocks = chain ? [...chain.blocks] : [...block.effectBlocks];
+  const effectBlocks = [...block.effectBlocks];
   const reorderable = effectBlocks.length >= 2;
   const { uiStore } = store;
-
-  const reorderEffect = (effectBlock: Block, delta: number) =>
-    chain
-      ? chain.reorderBlock(effectBlock, delta)
-      : block.reorderEffectBlock(effectBlock, delta);
-  const removeEffect = (effectBlock: Block) =>
-    chain
-      ? chain.removeBlock(effectBlock)
-      : block.removeEffectBlock(effectBlock);
-  const addEffect = (effect: Pattern) =>
-    chain ? chain.addCloneOfEffect(effect) : block.addCloneOfEffect(effect);
 
   const onDragEnd: OnDragEndResponder = action((result) => {
     if (!result.destination) return;
     const effectBlock = effectBlocks[result.source.index];
     if (!effectBlock) return;
-    reorderEffect(effectBlock, result.destination.index - result.source.index);
+    block.reorderEffectBlock(
+      effectBlock,
+      result.destination.index - result.source.index,
+    );
   });
 
   return (
@@ -153,7 +145,7 @@ export const BlockDevicePanel = observer(function BlockDevicePanel() {
             )}
             <Connector />
             <Droppable
-              droppableId={`device-${chain?.id ?? block.id}`}
+              droppableId={`device-${block.id}`}
               direction="horizontal"
             >
               {(provided) => (
@@ -180,8 +172,7 @@ export const BlockDevicePanel = observer(function BlockDevicePanel() {
                           {index > 0 && <Connector />}
                           <EffectUnit
                             effectBlock={effectBlock}
-                            onRemove={() => removeEffect(effectBlock)}
-                            isSelected={chain ? effectBlock === block : false}
+                            onRemove={() => block.removeEffectBlock(effectBlock)}
                             dragHandleProps={
                               reorderable ? prov.dragHandleProps : undefined
                             }
@@ -195,7 +186,7 @@ export const BlockDevicePanel = observer(function BlockDevicePanel() {
               )}
             </Droppable>
             <AddEffectUnit
-              onAddEffect={addEffect}
+              onAddEffect={(effect) => block.addCloneOfEffect(effect)}
               helpDescription={
                 chain
                   ? "Append an effect to this chain, applied to its composited input."
@@ -483,12 +474,10 @@ const PanelIconButton = function PanelIconButton({
 const EffectUnit = function EffectUnit({
   effectBlock,
   onRemove,
-  isSelected,
   dragHandleProps,
 }: {
   effectBlock: Block;
   onRemove: () => void;
-  isSelected: boolean;
   dragHandleProps: any;
 }) {
   const { uiStore } = useStore();
@@ -501,7 +490,7 @@ const EffectUnit = function EffectUnit({
       display="flex"
       flexDirection="column"
       bg="#1b212b"
-      border={`1px solid ${isSelected ? "#3182ce" : "#2f3a48"}`}
+      border="1px solid #2f3a48"
       borderRadius="4px"
       px={1.5}
       py={1}

--- a/src/components/RenderPipeline/BlockStackNode.tsx
+++ b/src/components/RenderPipeline/BlockStackNode.tsx
@@ -61,7 +61,6 @@ export const BlockStackNode = observer(function BlockStackNode({
   // renderTargetOut — meaning the pattern has to go to renderTargetIn.
   const evenNumberOfEffects = effectBlocks.length % 2 === 0;
   const patternTarget = evenNumberOfEffects ? renderTargetOut : renderTargetIn;
-  const scratchTarget = evenNumberOfEffects ? renderTargetIn : renderTargetOut;
   const pattern = parentBlock?.pattern ?? defaultPattern;
 
   return (
@@ -72,11 +71,14 @@ export const BlockStackNode = observer(function BlockStackNode({
         shaderMaterialKey={parentBlock?.id}
         renderTargetOut={patternTarget}
       />
+      {/* With an odd number of effects the pattern is in renderTargetIn, which
+          the first effect consumes — from then on it is free to serve as the
+          chain's scratch. */}
       <EffectChainNode
         basePriority={basePriority + 2}
         effectBlocks={effectBlocks}
         sourceTarget={patternTarget}
-        scratchTarget={scratchTarget}
+        scratchTarget={renderTargetIn}
         destinationTarget={renderTargetOut}
       />
     </>

--- a/src/components/RenderPipeline/BlockStackNode.tsx
+++ b/src/components/RenderPipeline/BlockStackNode.tsx
@@ -2,9 +2,8 @@ import defaultVertexShader from "@/src/shaders/default.vert";
 import blackFragmentShader from "@/src/shaders/black.frag";
 import conjurerCommon from "@/src/shaders/conjurer_common.frag";
 import { WebGLRenderTarget, ShaderChunk } from "three";
-import { useFrame, useThree } from "@react-three/fiber";
-import { useEffect } from "react";
-import { BlockNode } from "@/src/components/RenderPipeline/BlockNode";
+import { useFrame } from "@react-three/fiber";
+import { EffectChainNode } from "@/src/components/RenderPipeline/EffectChainNode";
 import { useStore } from "@/src/types/StoreContext";
 import { Block } from "@/src/types/Block";
 import { observer } from "mobx-react-lite";
@@ -20,6 +19,10 @@ type BlockStackNodeProps = {
   renderTargetIn: WebGLRenderTarget;
   renderTargetOut: WebGLRenderTarget;
 };
+
+// stable identity so a block stack without a block doesn't hand the effect
+// chain a new array every render
+const emptyEffectBlocks: Block[] = [];
 
 const defaultPattern = new Pattern("default", blackFragmentShader);
 
@@ -52,12 +55,13 @@ export const BlockStackNode = observer(function BlockStackNode({
     parentBlock.updateParameters(globalTime - startTime);
   }, basePriority);
 
-  // re-render this BlockStackNode if the number of effects changes
-  const invalidate = useThree(({ invalidate }) => invalidate);
-  useEffect(invalidate, [parentBlock?.effectBlocks.length, invalidate]);
-
-  const numberEffects = parentBlock?.effectBlocks.length ?? 0;
-  const evenNumberOfEffects = numberEffects % 2 === 0;
+  const effectBlocks = parentBlock?.effectBlocks ?? emptyEffectBlocks;
+  // The chain alternates its output from the back forwards and must finish in
+  // renderTargetOut, so with an odd number of effects the first one writes
+  // renderTargetOut — meaning the pattern has to go to renderTargetIn.
+  const evenNumberOfEffects = effectBlocks.length % 2 === 0;
+  const patternTarget = evenNumberOfEffects ? renderTargetOut : renderTargetIn;
+  const scratchTarget = evenNumberOfEffects ? renderTargetIn : renderTargetOut;
   const pattern = parentBlock?.pattern ?? defaultPattern;
 
   return (
@@ -66,23 +70,15 @@ export const BlockStackNode = observer(function BlockStackNode({
         pattern={pattern}
         priority={basePriority + 1}
         shaderMaterialKey={parentBlock?.id}
-        renderTargetOut={evenNumberOfEffects ? renderTargetOut : renderTargetIn}
+        renderTargetOut={patternTarget}
       />
-      {parentBlock?.effectBlocks.map((effect, i) => {
-        const isEven = i % 2 === 0;
-        // we want XNOR logical operation here, equivalent to strict equal for booleans
-        const swap = evenNumberOfEffects === isEven;
-        const pattern = effect.pattern;
-        return (
-          <pattern.Component
-            key={effect.id}
-            pattern={pattern}
-            priority={basePriority + i + 2}
-            renderTargetIn={swap ? renderTargetOut : renderTargetIn}
-            renderTargetOut={swap ? renderTargetIn : renderTargetOut}
-          />
-        );
-      })}
+      <EffectChainNode
+        basePriority={basePriority + 2}
+        effectBlocks={effectBlocks}
+        sourceTarget={patternTarget}
+        scratchTarget={scratchTarget}
+        destinationTarget={renderTargetOut}
+      />
     </>
   );
 });

--- a/src/components/RenderPipeline/EffectChainNode.tsx
+++ b/src/components/RenderPipeline/EffectChainNode.tsx
@@ -9,11 +9,13 @@ type EffectChainNodeProps = {
   // priority of the first effect's render pass; effect i renders at
   // basePriority + i
   basePriority: number;
-  // when set, this node drives each effect block's uniforms at that priority,
+  // when set, this node drives parameterBlock's uniforms at that priority,
   // which must come before basePriority. Chains hanging off a pattern block
   // leave this unset: the pattern block already updates its effects' params
   // along with its own.
   parameterPriority?: number;
+  // the chain block these effects belong to, whose timeline they run on
+  parameterBlock?: Block;
   effectBlocks: Block[];
   // holds the chain's input; read by the first effect and by nothing after it
   sourceTarget: WebGLRenderTarget;
@@ -38,6 +40,7 @@ type EffectChainNodeProps = {
 export const EffectChainNode = observer(function EffectChainNode({
   basePriority,
   parameterPriority,
+  parameterBlock,
   effectBlocks,
   sourceTarget,
   scratchTarget,
@@ -53,10 +56,10 @@ export const EffectChainNode = observer(function EffectChainNode({
 
   return (
     <>
-      {parameterPriority !== undefined && (
+      {parameterPriority !== undefined && parameterBlock && (
         <EffectChainParameterNode
           priority={parameterPriority}
-          effectBlocks={effectBlocks}
+          block={parameterBlock}
         />
       )}
       {effectBlocks.map((effectBlock, i) => {
@@ -77,14 +80,15 @@ export const EffectChainNode = observer(function EffectChainNode({
 
 type EffectChainParameterNodeProps = {
   priority: number;
-  effectBlocks: Block[];
+  block: Block;
 };
 
-// Drives the uniforms of a chain whose blocks each run on their own timeline,
-// ahead of the passes that consume them.
+// Drives a chain block's uniforms ahead of the passes that consume them. The
+// block's own update recurses into its effects, so they all run on its
+// timeline — the same relationship a pattern block has with its effects.
 const EffectChainParameterNode = observer(function EffectChainParameterNode({
   priority,
-  effectBlocks,
+  block,
 }: EffectChainParameterNodeProps) {
   const { audioStore } = useStore();
 
@@ -93,8 +97,7 @@ const EffectChainParameterNode = observer(function EffectChainParameterNode({
     // observableRequiresReaction is enabled, but it's fine. We don't want this
     // function to react to it - it runs every frame already.
     const { globalTime } = audioStore;
-    for (const effectBlock of effectBlocks)
-      effectBlock.updateParameters(globalTime - effectBlock.startTime);
+    block.updateParameters(globalTime - block.startTime);
   }, priority);
 
   return null;

--- a/src/components/RenderPipeline/EffectChainNode.tsx
+++ b/src/components/RenderPipeline/EffectChainNode.tsx
@@ -15,9 +15,11 @@ type EffectChainNodeProps = {
   // along with its own.
   parameterPriority?: number;
   effectBlocks: Block[];
-  // holds the chain's input; only ever read
+  // holds the chain's input; read by the first effect and by nothing after it
   sourceTarget: WebGLRenderTarget;
-  // the chain ping-pongs between this and destinationTarget
+  // the chain ping-pongs between this and destinationTarget. May be the source
+  // target itself when the caller has no third target to spare: the first
+  // effect consumes the source before anything writes the scratch.
   scratchTarget: WebGLRenderTarget;
   // receives the last effect's output
   destinationTarget: WebGLRenderTarget;

--- a/src/components/RenderPipeline/EffectChainNode.tsx
+++ b/src/components/RenderPipeline/EffectChainNode.tsx
@@ -1,0 +1,99 @@
+import { WebGLRenderTarget } from "three";
+import { useFrame, useThree } from "@react-three/fiber";
+import { useEffect } from "react";
+import { observer } from "mobx-react-lite";
+import { Block } from "@/src/types/Block";
+import { useStore } from "@/src/types/StoreContext";
+
+type EffectChainNodeProps = {
+  // priority of the first effect's render pass; effect i renders at
+  // basePriority + i
+  basePriority: number;
+  // when set, this node drives each effect block's uniforms at that priority,
+  // which must come before basePriority. Chains hanging off a pattern block
+  // leave this unset: the pattern block already updates its effects' params
+  // along with its own.
+  parameterPriority?: number;
+  effectBlocks: Block[];
+  // holds the chain's input; only ever read
+  sourceTarget: WebGLRenderTarget;
+  // the chain ping-pongs between this and destinationTarget
+  scratchTarget: WebGLRenderTarget;
+  // receives the last effect's output
+  destinationTarget: WebGLRenderTarget;
+};
+
+/**
+ * Runs an ordered list of effect blocks between a source and a destination
+ * render target.
+ *
+ * Effects alternate their output between the destination and the scratch target
+ * from the back of the chain forwards, so the last effect lands in the
+ * destination and no pass ever reads the target it writes. With an odd number of
+ * effects the first one writes the destination, so callers that also produce the
+ * source must put it in the scratch target in that case (see BlockStackNode).
+ */
+export const EffectChainNode = observer(function EffectChainNode({
+  basePriority,
+  parameterPriority,
+  effectBlocks,
+  sourceTarget,
+  scratchTarget,
+  destinationTarget,
+}: EffectChainNodeProps) {
+  // re-render this node if the number of effects changes
+  const invalidate = useThree(({ invalidate }) => invalidate);
+  useEffect(invalidate, [effectBlocks.length, invalidate]);
+
+  const lastIndex = effectBlocks.length - 1;
+  const targetOut = (index: number) =>
+    (lastIndex - index) % 2 === 0 ? destinationTarget : scratchTarget;
+
+  return (
+    <>
+      {parameterPriority !== undefined && (
+        <EffectChainParameterNode
+          priority={parameterPriority}
+          effectBlocks={effectBlocks}
+        />
+      )}
+      {effectBlocks.map((effectBlock, i) => {
+        const { pattern } = effectBlock;
+        return (
+          <pattern.Component
+            key={effectBlock.id}
+            pattern={pattern}
+            priority={basePriority + i}
+            renderTargetIn={i === 0 ? sourceTarget : targetOut(i - 1)}
+            renderTargetOut={targetOut(i)}
+          />
+        );
+      })}
+    </>
+  );
+});
+
+type EffectChainParameterNodeProps = {
+  priority: number;
+  effectBlocks: Block[];
+};
+
+// Drives the uniforms of a chain whose blocks each run on their own timeline,
+// ahead of the passes that consume them.
+const EffectChainParameterNode = observer(function EffectChainParameterNode({
+  priority,
+  effectBlocks,
+}: EffectChainParameterNodeProps) {
+  const { audioStore } = useStore();
+
+  useFrame(() => {
+    // mobx linting will complain about reading globalTime here if
+    // observableRequiresReaction is enabled, but it's fine. We don't want this
+    // function to react to it - it runs every frame already.
+    const { globalTime } = audioStore;
+    for (const effectBlock of effectBlocks)
+      effectBlock.updateParameters(globalTime - effectBlock.startTime);
+  }, priority);
+
+  return null;
+});

--- a/src/components/RenderPipeline/RenderPipelineV2.tsx
+++ b/src/components/RenderPipeline/RenderPipelineV2.tsx
@@ -9,7 +9,9 @@ import { observer } from "mobx-react-lite";
 import { WebGLRenderTarget } from "three";
 import { BlockStackNode } from "./BlockStackNode";
 import { BlockNode } from "./BlockNode";
+import { EffectChainNode } from "./EffectChainNode";
 import { LayerV2 } from "@/src/types/Layer/LayerV2";
+import { EffectChain } from "@/src/types/EffectChain";
 import blackFragmentShader from "@/src/shaders/black.frag";
 import defaultVertexShader from "@/src/shaders/default.vert";
 
@@ -18,13 +20,17 @@ type Props = {
 };
 
 // useFrame priorities run in ascending order, so these bands define the frame
-// schedule: every block stack of a layer renders before the layer's internal
-// merge chain, and every layer renders before the cross-layer merge chain.
+// schedule: within a layer, every block stack renders, then the layer's internal
+// merge chain folds them together, then the layer's effect chain processes that
+// merged output. Every layer completes before the cross-layer merge, which is
+// followed by the experience's global effect chain writing the final frame.
 // Each layer's band accommodates up to 50 concurrent blocks (at 100 priorities
 // per block stack) before colliding with its merge chain.
 const LAYER_PRIORITY_BAND = 10_000;
 const LAYER_MERGE_OFFSET = 5_000;
+const LAYER_EFFECT_CHAIN_OFFSET = 6_000;
 const CROSS_LAYER_MERGE_PRIORITY = 1_000_000;
+const GLOBAL_EFFECT_CHAIN_PRIORITY = 1_100_000;
 
 export const RenderPipelineV2 = observer(function RenderPipeline({
   renderTargetZ,
@@ -51,8 +57,10 @@ export const RenderPipelineV2 = observer(function RenderPipeline({
           />
         ) : null,
       )}
-      <MergeNodes
-        basePriority={CROSS_LAYER_MERGE_PRIORITY}
+      <MergeThroughEffectChain
+        mergePriority={CROSS_LAYER_MERGE_PRIORITY}
+        chainPriority={GLOBAL_EFFECT_CHAIN_PRIORITY}
+        chain={store.globalEffectChain}
         inputs={mergeInputs}
         destinationTarget={renderTargetZ}
       />
@@ -84,8 +92,10 @@ const LayerNode = observer(function LayerNode({
           renderTargetOut={renderTargets[i + 1]}
         />
       ))}
-      <MergeNodes
-        basePriority={basePriority + LAYER_MERGE_OFFSET}
+      <MergeThroughEffectChain
+        mergePriority={basePriority + LAYER_MERGE_OFFSET}
+        chainPriority={basePriority + LAYER_EFFECT_CHAIN_OFFSET}
+        chain={layer.effectChain}
         inputs={blocks.map((block, i) => ({
           target: renderTargets[i + 1],
           // opacity is applied here, after the block's entire effect chain
@@ -94,6 +104,55 @@ const LayerNode = observer(function LayerNode({
         }))}
         destinationTarget={destinationTarget}
       />
+    </>
+  );
+});
+
+type MergeThroughEffectChainProps = {
+  mergePriority: number;
+  chainPriority: number;
+  chain: EffectChain;
+  inputs: MergeInput[];
+  destinationTarget: WebGLRenderTarget;
+};
+
+// Merges its inputs and then runs them through a post-composite effect chain.
+// With no effect in the signal path the merge writes the destination directly,
+// so an experience without effect chains renders in exactly as many passes as it
+// would without them.
+const MergeThroughEffectChain = observer(function MergeThroughEffectChain({
+  mergePriority,
+  chainPriority,
+  chain,
+  inputs,
+  destinationTarget,
+}: MergeThroughEffectChainProps) {
+  // Held by this component rather than the chain-active branch below so that
+  // the targets survive effects coming in and out of the signal path as the
+  // playhead moves.
+  const chainSource = useRenderTarget();
+  const chainScratch = useRenderTarget();
+
+  const activeEffects = chain.activeBlocks;
+  const chainActive = activeEffects.length > 0;
+
+  return (
+    <>
+      <MergeNodes
+        basePriority={mergePriority}
+        inputs={inputs}
+        destinationTarget={chainActive ? chainSource : destinationTarget}
+      />
+      {chainActive && (
+        <EffectChainNode
+          basePriority={chainPriority + 1}
+          parameterPriority={chainPriority}
+          effectBlocks={activeEffects}
+          sourceTarget={chainSource}
+          scratchTarget={chainScratch}
+          destinationTarget={destinationTarget}
+        />
+      )}
     </>
   );
 });

--- a/src/components/RenderPipeline/RenderPipelineV2.tsx
+++ b/src/components/RenderPipeline/RenderPipelineV2.tsx
@@ -153,7 +153,9 @@ const MergeThroughPopulatedChain = observer(function MergeThroughPopulatedChain(
   const chainSource = useRenderTarget();
   const chainScratch = useRenderTarget();
 
-  const activeEffects = chain.activeBlocks;
+  // chain blocks never overlap, so at most one is in the signal path
+  const activeBlock = chain.activeBlocks[0] ?? null;
+  const activeEffects = activeBlock?.effectBlocks ?? [];
   const chainActive = activeEffects.length > 0;
 
   return (
@@ -163,10 +165,11 @@ const MergeThroughPopulatedChain = observer(function MergeThroughPopulatedChain(
         inputs={inputs}
         destinationTarget={chainActive ? chainSource : destinationTarget}
       />
-      {chainActive && (
+      {chainActive && activeBlock && (
         <EffectChainNode
           basePriority={chainPriority + 1}
           parameterPriority={chainPriority}
+          parameterBlock={activeBlock}
           effectBlocks={activeEffects}
           sourceTarget={chainSource}
           scratchTarget={chainScratch}

--- a/src/components/RenderPipeline/RenderPipelineV2.tsx
+++ b/src/components/RenderPipeline/RenderPipelineV2.tsx
@@ -117,18 +117,38 @@ type MergeThroughEffectChainProps = {
 };
 
 // Merges its inputs and then runs them through a post-composite effect chain.
-// With no effect in the signal path the merge writes the destination directly,
-// so an experience without effect chains renders in exactly as many passes as it
-// would without them.
+// An empty chain merges straight to the destination from here, which keeps the
+// chain's render targets unallocated for the layers — and the experiences —
+// that hold no effects at all.
 const MergeThroughEffectChain = observer(function MergeThroughEffectChain({
+  chain,
+  ...props
+}: MergeThroughEffectChainProps) {
+  if (chain.blocks.length === 0)
+    return (
+      <MergeNodes
+        basePriority={props.mergePriority}
+        inputs={props.inputs}
+        destinationTarget={props.destinationTarget}
+      />
+    );
+
+  return <MergeThroughPopulatedChain chain={chain} {...props} />;
+});
+
+// Merges its inputs through a chain that holds effects, of which any number may
+// be outside their time window at the playhead. With none of them in the signal
+// path the merge writes the destination directly, so a chain costs extra passes
+// only while it is actually doing something.
+const MergeThroughPopulatedChain = observer(function MergeThroughPopulatedChain({
   mergePriority,
   chainPriority,
   chain,
   inputs,
   destinationTarget,
 }: MergeThroughEffectChainProps) {
-  // Held by this component rather than the chain-active branch below so that
-  // the targets survive effects coming in and out of the signal path as the
+  // Keyed to the chain rather than to the effects in the signal path, so that
+  // the targets are allocated once and survive effects coming and going as the
   // playhead moves.
   const chainSource = useRenderTarget();
   const chainScratch = useRenderTarget();

--- a/src/components/Timeline/AddChainEffectMenu.tsx
+++ b/src/components/Timeline/AddChainEffectMenu.tsx
@@ -1,0 +1,72 @@
+import {
+  IconButton,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Portal,
+} from "@chakra-ui/react";
+import { action } from "mobx";
+import { MdAutoFixHigh } from "react-icons/md";
+import { playgroundEffects } from "@/src/effects/effects";
+import { EffectChain } from "@/src/types/EffectChain";
+import { useStore } from "@/src/types/StoreContext";
+import { hoverHelpProps } from "@/src/utils/hoverHelp";
+
+type Props = {
+  chain: EffectChain;
+  helpTitle: string;
+  helpDescription: string;
+};
+
+// Appends an effect from the registry to a post-composite effect chain. The
+// effect lands on the timeline at the playhead, where it can be moved and
+// resized like any other block.
+export const AddChainEffectMenu = function AddChainEffectMenu({
+  chain,
+  helpTitle,
+  helpDescription,
+}: Props) {
+  const { uiStore } = useStore();
+  return (
+    <Menu>
+      <MenuButton
+        as={IconButton}
+        minW="20px"
+        w="20px"
+        h="20px"
+        flexShrink={0}
+        variant="unstyled"
+        color="gray.600"
+        _hover={{ color: "blue.600" }}
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        aria-label={helpTitle}
+        title={helpTitle}
+        icon={<MdAutoFixHigh size={13} />}
+        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+        {...hoverHelpProps(uiStore, helpTitle, helpDescription)}
+      />
+      <Portal>
+        {/* above the sticky timeline headers and the timer/waveform row */}
+        <MenuList
+          rootProps={{ style: { zIndex: 20 } }}
+          maxH="300px"
+          overflowY="auto"
+        >
+          {playgroundEffects.map((effect) => (
+            <MenuItem
+              key={effect.name}
+              onClick={action(() => {
+                chain.addCloneOfEffect(effect);
+              })}
+            >
+              {effect.name}
+            </MenuItem>
+          ))}
+        </MenuList>
+      </Portal>
+    </Menu>
+  );
+};

--- a/src/components/Timeline/GlobalEffectRow.tsx
+++ b/src/components/Timeline/GlobalEffectRow.tsx
@@ -1,0 +1,124 @@
+import { Box, HStack, IconButton, Text } from "@chakra-ui/react";
+import { action } from "mobx";
+import { observer } from "mobx-react-lite";
+import { useRef } from "react";
+import { MdBlurOn } from "react-icons/md";
+import { useStore } from "@/src/types/StoreContext";
+import { TIMELINE_HEADER_WIDTH } from "@/src/types/UIStore";
+import { MAX_TIME } from "@/src/utils/time";
+import { hoverHelpProps } from "@/src/utils/hoverHelp";
+import { AddChainEffectMenu } from "@/src/components/Timeline/AddChainEffectMenu";
+import { TimelineBlockStack } from "@/src/components/TimelineBlockStack/TimelineBlockStack";
+
+// Tall enough for the row's header controls when the chain is empty.
+const EMPTY_ROW_HEIGHT = 26;
+
+/**
+ * The experience's global effect chain, pinned below the layer stack: these
+ * effects process the merged output of every layer, which is why the row sits
+ * downstream of them all.
+ *
+ * Shaped like the Add-layer row — a sticky header gutter plus a spacer as wide
+ * as a layer's content — so the header stays pinned across the full horizontal
+ * scroll.
+ */
+export const GlobalEffectRow = observer(function GlobalEffectRow() {
+  const store = useStore();
+  const { audioStore, uiStore, globalEffectChain: chain } = store;
+
+  const contentRef = useRef<HTMLDivElement>(null);
+  const blocks = chain.blocks;
+  const height = Math.max(chain.height, EMPTY_ROW_HEIGHT);
+
+  return (
+    <HStack
+      spacing={0}
+      flexShrink={0}
+      alignItems="flex-start"
+      height={`${height}px`}
+    >
+      <Box
+        position="sticky"
+        left={0}
+        zIndex={11}
+        width={`${TIMELINE_HEADER_WIDTH}px`}
+        height="100%"
+        flexShrink={0}
+        boxSizing="border-box"
+        bgColor="gray.500"
+        borderTopWidth={1}
+        borderRightWidth={1}
+        borderColor="black"
+      >
+        {/* Stick below the 80px TimerAndWaveform, as the layer headers do */}
+        <HStack
+          position="sticky"
+          top="80px"
+          width="100%"
+          px={1}
+          spacing={1}
+          justify="center"
+          minH="20px"
+          bgColor="gray.500"
+        >
+          <Text fontSize={11} fontWeight="bold" color="black" noOfLines={1}>
+            Global FX
+          </Text>
+          <AddChainEffectMenu
+            chain={chain}
+            helpTitle="Add global effect"
+            helpDescription="Append an effect applied to the entire frame, after every layer is merged together."
+          />
+          {blocks.length > 0 && (
+            <IconButton
+              minW="20px"
+              w="20px"
+              h="20px"
+              variant="unstyled"
+              color={chain.visible ? "blue.600" : "gray.600"}
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              aria-label="Bypass global effects"
+              title="Bypass global effects"
+              icon={<MdBlurOn size={15} />}
+              onClick={action(() => chain.toggleVisible())}
+              {...hoverHelpProps(
+                uiStore,
+                "Global effect chain",
+                "Take the global effect chain out of the signal path without deleting it.",
+              )}
+            />
+          )}
+        </HStack>
+      </Box>
+      <Box
+        ref={contentRef}
+        position="relative"
+        width={uiStore.timeToXPixels(MAX_TIME)}
+        height="100%"
+        flexShrink={0}
+        boxSizing="border-box"
+        bgColor="gray.500"
+        borderTopWidth={1}
+        borderColor="black"
+        opacity={chain.visible ? 1 : 0.4}
+        onClick={action((e) => {
+          audioStore.setTimeWithCursor(
+            Math.max(
+              0,
+              uiStore.xToTime(
+                e.clientX - contentRef.current!.getBoundingClientRect().x,
+              ),
+            ),
+          );
+          store.deselectAll();
+        })}
+      >
+        {blocks.map((block) => (
+          <TimelineBlockStack key={block.id} patternBlock={block} />
+        ))}
+      </Box>
+    </HStack>
+  );
+});

--- a/src/components/Timeline/TimelineEffectChainStrip.tsx
+++ b/src/components/Timeline/TimelineEffectChainStrip.tsx
@@ -1,0 +1,39 @@
+import { Box } from "@chakra-ui/react";
+import { observer } from "mobx-react-lite";
+import { EffectChain } from "@/src/types/EffectChain";
+import { TimelineBlockStack } from "@/src/components/TimelineBlockStack/TimelineBlockStack";
+
+type Props = {
+  chain: EffectChain;
+  // vertical start of the strip within its layer row, below the block lanes
+  topOffset: number;
+};
+
+// A layer's effect chain, laid out on the timeline directly beneath the blocks
+// it processes. An empty chain has no height, so a layer without one occupies
+// exactly the space its blocks do.
+export const TimelineEffectChainStrip = observer(
+  function TimelineEffectChainStrip({ chain, topOffset }: Props) {
+    const blocks = chain.blocks;
+    if (blocks.length === 0) return null;
+
+    return (
+      <Box
+        position="absolute"
+        left={0}
+        top={`${topOffset}px`}
+        width="100%"
+        height={`${chain.height}px`}
+        bgColor="blackAlpha.200"
+        borderTopWidth={1}
+        borderColor="blackAlpha.600"
+        borderStyle="dashed"
+        opacity={chain.visible ? 1 : 0.4}
+      >
+        {blocks.map((block) => (
+          <TimelineBlockStack key={block.id} patternBlock={block} />
+        ))}
+      </Box>
+    );
+  },
+);

--- a/src/components/Timeline/TimelineLayer.tsx
+++ b/src/components/Timeline/TimelineLayer.tsx
@@ -9,7 +9,6 @@ import { Draggable } from "@hello-pangea/dnd";
 import { TimelineLayerHeader } from "@/src/components/Timeline/TimelineLayerHeader";
 import { TimelineBlockStack } from "@/src/components/TimelineBlockStack/TimelineBlockStack";
 import { TimelineEffectChainStrip } from "@/src/components/Timeline/TimelineEffectChainStrip";
-import { LayerV2 } from "@/src/types/Layer/LayerV2";
 
 type TimelineLayerProps = {
   index: number;
@@ -50,7 +49,7 @@ export const TimelineLayer = observer(function TimelineLayer({
           <TimelineBlockStack key={block.id} patternBlock={block} />
         ));
   const effectChainStrip =
-    collapsed || !(layer instanceof LayerV2) ? null : (
+    collapsed || !layer.effectChain ? null : (
       <TimelineEffectChainStrip
         chain={layer.effectChain}
         topOffset={layer.blockLanesHeight}

--- a/src/components/Timeline/TimelineLayer.tsx
+++ b/src/components/Timeline/TimelineLayer.tsx
@@ -8,6 +8,8 @@ import { useRef } from "react";
 import { Draggable } from "@hello-pangea/dnd";
 import { TimelineLayerHeader } from "@/src/components/Timeline/TimelineLayerHeader";
 import { TimelineBlockStack } from "@/src/components/TimelineBlockStack/TimelineBlockStack";
+import { TimelineEffectChainStrip } from "@/src/components/Timeline/TimelineEffectChainStrip";
+import { LayerV2 } from "@/src/types/Layer/LayerV2";
 
 type TimelineLayerProps = {
   index: number;
@@ -47,6 +49,13 @@ export const TimelineLayer = observer(function TimelineLayer({
         .map((block) => (
           <TimelineBlockStack key={block.id} patternBlock={block} />
         ));
+  const effectChainStrip =
+    collapsed || !(layer instanceof LayerV2) ? null : (
+      <TimelineEffectChainStrip
+        chain={layer.effectChain}
+        topOffset={layer.blockLanesHeight}
+      />
+    );
 
   return (
     <Draggable
@@ -97,6 +106,7 @@ export const TimelineLayer = observer(function TimelineLayer({
             })}
           >
             {blockStacks}
+            {effectChainStrip}
           </Box>
         </HStack>
       )}

--- a/src/components/Timeline/TimelineLayerHeader.tsx
+++ b/src/components/Timeline/TimelineLayerHeader.tsx
@@ -32,7 +32,6 @@ import {
 import { FaTrashAlt } from "react-icons/fa";
 import type { DraggableProvidedDragHandleProps } from "@hello-pangea/dnd";
 import { hoverHelpProps } from "@/src/utils/hoverHelp";
-import { LayerV2 } from "@/src/types/Layer/LayerV2";
 import { AddChainEffectMenu } from "@/src/components/Timeline/AddChainEffectMenu";
 
 type Props = {
@@ -58,7 +57,7 @@ export const TimelineLayerHeader = observer(function TimelineLayerHeader({
   const blockCount = layer.getAllBlocks().length;
   const collapsed = layer.collapsed;
 
-  const effectChain = layer instanceof LayerV2 ? layer.effectChain : null;
+  const { effectChain } = layer;
 
   const confirmDelete = useDisclosure();
 

--- a/src/components/Timeline/TimelineLayerHeader.tsx
+++ b/src/components/Timeline/TimelineLayerHeader.tsx
@@ -23,10 +23,17 @@ import { Layer } from "@/src/types/Layer";
 import { action, runInAction } from "mobx";
 import { useEffect } from "react";
 import { AiFillEye, AiFillEyeInvisible } from "react-icons/ai";
-import { MdDragIndicator, MdExpandMore, MdChevronRight } from "react-icons/md";
+import {
+  MdDragIndicator,
+  MdExpandMore,
+  MdChevronRight,
+  MdBlurOn,
+} from "react-icons/md";
 import { FaTrashAlt } from "react-icons/fa";
 import type { DraggableProvidedDragHandleProps } from "@hello-pangea/dnd";
 import { hoverHelpProps } from "@/src/utils/hoverHelp";
+import { LayerV2 } from "@/src/types/Layer/LayerV2";
+import { AddChainEffectMenu } from "@/src/components/Timeline/AddChainEffectMenu";
 
 type Props = {
   index: number;
@@ -50,6 +57,8 @@ export const TimelineLayerHeader = observer(function TimelineLayerHeader({
   const displayName = layer.name || `Layer ${index + 1}`;
   const blockCount = layer.getAllBlocks().length;
   const collapsed = layer.collapsed;
+
+  const effectChain = layer instanceof LayerV2 ? layer.effectChain : null;
 
   const confirmDelete = useDisclosure();
 
@@ -222,6 +231,39 @@ export const TimelineLayerHeader = observer(function TimelineLayerHeader({
               "Hide this layer from the render without deleting its blocks.",
             )}
           />
+
+          {effectChain && (
+            <AddChainEffectMenu
+              chain={effectChain}
+              helpTitle="Add layer effect"
+              helpDescription="Append an effect applied to everything this layer renders, after its blocks are merged together."
+            />
+          )}
+
+          {effectChain && effectChain.blocks.length > 0 && (
+            <IconButton
+              minW="20px"
+              w="20px"
+              h="20px"
+              variant="unstyled"
+              color={effectChain.visible ? "blue.600" : "gray.500"}
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              aria-label="Bypass layer effects"
+              title="Bypass layer effects"
+              icon={<MdBlurOn size={15} />}
+              onClick={action((e) => {
+                effectChain.toggleVisible();
+                e.stopPropagation();
+              })}
+              {...hoverHelpProps(
+                uiStore,
+                "Layer effect chain",
+                "Take this layer's effect chain out of the signal path without deleting it.",
+              )}
+            />
+          )}
 
           <IconButton
             minW="20px"

--- a/src/components/Timeline/TimelineLayerStack.tsx
+++ b/src/components/Timeline/TimelineLayerStack.tsx
@@ -11,6 +11,7 @@ import { useRef } from "react";
 import { useStore } from "@/src/types/StoreContext";
 import { PlayHead } from "@/src/components/PlayHead";
 import { TimelineLayer } from "@/src/components/Timeline/TimelineLayer";
+import { GlobalEffectRow } from "@/src/components/Timeline/GlobalEffectRow";
 import { BeatGridOverlay } from "@/src/components/BeatGrid/BeatGridOverlay";
 import { TIMELINE_HEADER_WIDTH } from "@/src/types/UIStore";
 import { MAX_TIME } from "@/src/utils/time";
@@ -84,6 +85,7 @@ export const TimelineLayerStack = observer(function TimelineLayerStack() {
           )}
         </Droppable>
       </DragDropContext>
+      <GlobalEffectRow />
       {/* Row spanning the FULL scroll width (the sticky header gutter + a spacer
           matching a layer's content width), mirroring a layer row. A plain
           width="100%" only spans the viewport-wide VStack, so the sticky box's

--- a/src/components/TimelineBlockStack/BlockAutomationLanes.tsx
+++ b/src/components/TimelineBlockStack/BlockAutomationLanes.tsx
@@ -96,6 +96,9 @@ const gatherLanes = (block: Block): Lane[] => {
   const lanes: Lane[] = [];
   for (const [uniformName, param] of Object.entries(block.pattern.params)) {
     if (!block.lanedParams.has(uniformName)) continue;
+    // a lane persisted before the block moved into an effect chain, where
+    // nothing consumes opacity
+    if (uniformName === "u_opacity" && !block.opacityApplies) continue;
     lanes.push({
       ownerBlock: block,
       uniformName,

--- a/src/components/TimelineBlockStack/BlockDotRow.tsx
+++ b/src/components/TimelineBlockStack/BlockDotRow.tsx
@@ -47,7 +47,11 @@ const gatherSignals = (block: Block) => {
   const autoFading = !!block.layer?.autoOpacityVariations(block);
 
   const patternSignals: Signal[] = Object.entries(block.pattern.params)
-    .filter(([uniformName]) => !BASE_EXCLUDED.includes(uniformName))
+    .filter(
+      ([uniformName]) =>
+        !BASE_EXCLUDED.includes(uniformName) &&
+        (uniformName !== "u_opacity" || block.opacityApplies),
+    )
     .map(([uniformName, patternParam]) => {
       const isOpacity = uniformName === "u_opacity";
       // opacity is special: the pipeline writes the live crossfade value back
@@ -168,18 +172,20 @@ export const BlockDotRow = observer(function BlockDotRow({
       onMouseLeave={() => setHovered(false)}
     >
       <HStack spacing="3px" px={2} pb={1} justify="center">
-        <Box
-          as="span"
-          width="7px"
-          height="7px"
-          borderRadius="50%"
-          bg={opacityFill}
-          border={
-            opacityFill === "transparent"
-              ? `1px solid ${DEFAULT_BORDER}`
-              : undefined
-          }
-        />
+        {block.opacityApplies && (
+          <Box
+            as="span"
+            width="7px"
+            height="7px"
+            borderRadius="50%"
+            bg={opacityFill}
+            border={
+              opacityFill === "transparent"
+                ? `1px solid ${DEFAULT_BORDER}`
+                : undefined
+            }
+          />
+        )}
         <Text as="span" fontSize="9px" fontWeight={600} color={AUTHORED_COLOR}>
           {authoredCount}●
         </Text>

--- a/src/components/TimelineBlockStack/BlockOpacityEdgeLine.tsx
+++ b/src/components/TimelineBlockStack/BlockOpacityEdgeLine.tsx
@@ -22,6 +22,9 @@ export const BlockOpacityEdgeLine = observer(function BlockOpacityEdgeLine({
   const { uiStore } = useStore();
   const { fadeInEnd, fadeOutStart } = opacityFadeExtents(block);
 
+  // an effect's output is never merged, so it has no opacity to ramp
+  if (!block.opacityApplies) return null;
+
   // nothing to show when the block is at full opacity throughout
   if (fadeInEnd === null && fadeOutStart === null) return null;
 

--- a/src/components/TimelineBlockStack/PatternOrEffectBlock.tsx
+++ b/src/components/TimelineBlockStack/PatternOrEffectBlock.tsx
@@ -40,6 +40,12 @@ export const PatternOrEffectBlock = observer(function PatternOrEffectBlock({
   const color = isSelected ? "blue.500" : "white";
   const label = blockHeaderLabel(block);
   const locked = block.locked;
+  // The playground is keyed by pattern, so a block whose pattern has no
+  // playground counterpart — an effect chain block, whose source is the chain's
+  // composited input — has nothing to open.
+  const editableInPlayground = playgroundStore.patternBlocks.some(
+    (playgroundBlock) => playgroundBlock.pattern.name === block.pattern.name,
+  );
   return (
     <HStack
       position="relative"
@@ -100,25 +106,27 @@ export const PatternOrEffectBlock = observer(function PatternOrEffectBlock({
         alignSelf="stretch"
         bg="gray.700"
       >
-        <IconButton
-          variant="ghost"
-          size="xs"
-          aria-label="Edit in playground"
-          title="Edit in playground"
-          height={6}
-          icon={<FaPencilAlt size={11} />}
-          onClick={action((e: ReactMouseEvent) => {
-            e.stopPropagation();
-            if (!loadBlockIntoPlayground(playgroundStore, block)) return;
-            store.pause();
-            uiStore.patternDrawerOpen = true;
-          })}
-          {...hoverHelpProps(
-            uiStore,
-            "Edit in playground",
-            "Open the playground with this block's pattern, effects, and parameter values.",
-          )}
-        />
+        {editableInPlayground && (
+          <IconButton
+            variant="ghost"
+            size="xs"
+            aria-label="Edit in playground"
+            title="Edit in playground"
+            height={6}
+            icon={<FaPencilAlt size={11} />}
+            onClick={action((e: ReactMouseEvent) => {
+              e.stopPropagation();
+              if (!loadBlockIntoPlayground(playgroundStore, block)) return;
+              store.pause();
+              uiStore.patternDrawerOpen = true;
+            })}
+            {...hoverHelpProps(
+              uiStore,
+              "Edit in playground",
+              "Open the playground with this block's pattern, effects, and parameter values.",
+            )}
+          />
+        )}
         {uiStore.canTimelineZoom && (
           <IconButton
             variant="ghost"

--- a/src/patterns/EffectChainSource.ts
+++ b/src/patterns/EffectChainSource.ts
@@ -1,0 +1,12 @@
+import { Pattern } from "@/src/types/Pattern";
+
+/**
+ * The source of a block in an effect chain: the composited output the chain is
+ * handed, standing where a pattern block has its pattern.
+ *
+ * Like Opacity, it carries no shader. The pipeline feeds the composite texture
+ * straight into the block's first effect, so this is never rendered — it exists
+ * so a chain block is an ordinary Block, with a name to show on the timeline
+ * and an entry in the pattern registry for serialization to round-trip.
+ */
+export const EffectChainSource = () => new Pattern("Effects", "", {});

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -155,14 +155,24 @@ export class Block {
     saveBlockLanes(this.store.experienceName, this.id, [...this.lanedParams]);
   };
 
+  /**
+   * Whether anything consumes this block's opacity.
+   *
+   * Opacity is applied by the merge shader where a block's output is combined
+   * with its siblings'. An effect never reaches a merge — it is one pass inside
+   * a pattern block's chain, or inside a layer or global effect chain — so its
+   * opacity would be authored into a void.
+   */
+  get opacityApplies(): boolean {
+    return !this.parentBlock && !this.inEffectChain;
+  }
+
   // uniform names on this block that can be given an automation lane: excludes
   // machinery uniforms and opacity on effects (applied per pattern). Palettes
   // are included — their lane shows discrete color regions over time.
   get lanableParamNames(): string[] {
     const excluded = new Set(["u_time", "u_texture"]);
-    // opacity is applied per pattern block when its output is merged; an effect
-    // has no merge of its own
-    if (this.parentBlock || this.inEffectChain) excluded.add("u_opacity");
+    if (!this.opacityApplies) excluded.add("u_opacity");
     return Object.keys(this.pattern.params).filter(
       (name) => !excluded.has(name),
     );

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -43,6 +43,11 @@ export class Block {
   parentBlock: Block | null = null; // if this is an effect block, this is the pattern block that it is applied to
   effectBlocks: Block[] = [];
 
+  // true while this block is an entry in a layer's or the experience's effect
+  // chain (see EffectChain), where it processes composited output rather than
+  // producing its own
+  inEffectChain = false;
+
   startTime: number = 0; // global time that block starts playing at in seconds
   duration: number = 5; // duration that block plays for in seconds
 
@@ -155,7 +160,9 @@ export class Block {
   // are included — their lane shows discrete color regions over time.
   get lanableParamNames(): string[] {
     const excluded = new Set(["u_time", "u_texture"]);
-    if (this.parentBlock) excluded.add("u_opacity");
+    // opacity is applied per pattern block when its output is merged; an effect
+    // has no merge of its own
+    if (this.parentBlock || this.inEffectChain) excluded.add("u_opacity");
     return Object.keys(this.pattern.params).filter(
       (name) => !excluded.has(name),
     );
@@ -723,6 +730,7 @@ export class Block {
     newBlock.duration = this.duration;
     newBlock.locked = this.locked;
     newBlock.layer = this.layer;
+    newBlock.inEffectChain = this.inEffectChain;
 
     newBlock.parameterVariations = { ...this.parameterVariations };
     Object.entries(newBlock.parameterVariations).forEach(([key, value]) => {

--- a/src/types/EffectChain.ts
+++ b/src/types/EffectChain.ts
@@ -29,6 +29,8 @@ export class EffectChain implements Layer {
   visible = true;
   // satisfies Layer; a chain strip has no collapsed state of its own
   collapsed = false;
+  // a chain is the end of the line: its own blocks carry no further chain
+  effectChain = null;
 
   blocks: Block[] = [];
 
@@ -124,6 +126,11 @@ export class EffectChain implements Layer {
   // chain lays out exactly as it would without the feature.
   get height() {
     return this.laneHeights.reduce((sum, laneHeight) => sum + laneHeight, 0);
+  }
+
+  // a chain's blocks are all the vertical space it has
+  get blockLanesHeight() {
+    return this.height;
   }
 
   blockTopOffset = (block: Block) => {

--- a/src/types/EffectChain.ts
+++ b/src/types/EffectChain.ts
@@ -6,16 +6,20 @@ import type { Pattern } from "@/src/types/Pattern";
 import type { Variation } from "@/src/types/Variations/Variation";
 import { generateId } from "@/src/utils/id";
 import { DEFAULT_BLOCK_DURATION } from "@/src/utils/time";
-import { defaultEffectMap } from "@/src/effects/effects";
+import { EffectChainSource } from "@/src/patterns/EffectChainSource";
 
 // used for a block's lane until its actual rendered height is reported
 const UNMEASURED_BLOCK_HEIGHT = 50;
 
 /**
- * An ordered chain of effect blocks applied to already-composited output —
- * either one layer's merged blocks or the entire layer stack. Position in
- * `blocks` is signal order; each block's start time and duration decide when it
- * is in the signal path at all.
+ * The effects applied to already-composited output — either one layer's merged
+ * blocks or the entire layer stack.
+ *
+ * A chain holds blocks the way a layer does, and each block holds a stack of
+ * effects the way a pattern block does: the block owns the time bounds, and the
+ * effects inside it share those bounds and run in the order they are stacked.
+ * Blocks never overlap, so the chain's own ordering is purely chronological and
+ * carries no signal meaning.
  *
  * It implements Layer so that the timeline's block components (drag, resize,
  * selection, automation lanes) drive chain blocks through the same code paths
@@ -179,21 +183,33 @@ export class EffectChain implements Layer {
     this.visible = !this.visible;
   };
 
-  // Append an effect to the end of the chain, playing from the playhead.
+  /**
+   * Starts a new chain block at the playhead holding this effect.
+   *
+   * Effects live inside a chain block rather than alongside it, so this is how
+   * a chain gains a block; further effects are stacked onto an existing one
+   * through Block.addCloneOfEffect.
+   */
   addCloneOfEffect = (effect: Pattern) => {
-    const block = new Block(this.store, effect.clone());
-    block.setTiming({
-      startTime: this.store.audioStore.globalTime,
-      duration: DEFAULT_BLOCK_DURATION,
-    });
+    const { startTime, duration } = this.getNextValidStartAndDuration(
+      this.store.audioStore.globalTime,
+      DEFAULT_BLOCK_DURATION,
+    );
+    const block = new Block(this.store, EffectChainSource());
+    block.setTiming({ startTime, duration });
     this.addBlock(block);
+    block.addCloneOfEffect(effect);
     return block;
   };
 
+  // kept in start time order, which is the only order a chain block has: its
+  // effects carry the signal order, and blocks never overlap
   addBlock = (block: Block) => {
     block.layer = this;
     block.inEffectChain = true;
-    this.blocks.push(block);
+    const index = this.blocks.findIndex((b) => b.startTime > block.startTime);
+    if (index === -1) this.blocks.push(block);
+    else this.blocks.splice(index, 0, block);
   };
 
   removeBlock = (block: Block) => {
@@ -204,28 +220,14 @@ export class EffectChain implements Layer {
     block.inEffectChain = false;
   };
 
-  // Move a block `delta` positions along the chain, changing the order its
-  // effect is applied in.
-  reorderBlock = (block: Block, delta: number) => {
-    const index = this.blocks.indexOf(block);
-    if (index < 0) return;
-
-    const newIndex = index + delta;
-    if (newIndex < 0 || newIndex >= this.blocks.length) return;
-
-    this.blocks.splice(index, 1);
-    this.blocks.splice(newIndex, 0, block);
-  };
-
-  // Only effects belong in a chain, so a pattern block dropped here is ignored.
   insertCloneOfBlock = (block: Block) => {
-    if (!defaultEffectMap[block.pattern.name]) return;
     const clone = block.clone();
     clone.regenerateId();
-    clone.setTiming({
-      startTime: this.store.audioStore.globalTime,
-      duration: block.duration,
-    });
+    const { startTime, duration } = this.getNextValidStartAndDuration(
+      this.store.audioStore.globalTime,
+      block.duration,
+    );
+    clone.setTiming({ startTime, duration });
     this.addBlock(clone);
   };
 
@@ -233,13 +235,48 @@ export class EffectChain implements Layer {
     return this.blocks.slice();
   }
 
+  // The first gap at or after fromTime that no block occupies. Chain blocks
+  // apply in series to the same composited input, so overlapping them would
+  // leave their order to something the timeline cannot show.
   getNextValidStartAndDuration(fromTime: number, maxDuration: number) {
-    return { startTime: fromTime, duration: maxDuration };
+    let startTime = fromTime;
+    for (const block of this.blocks) {
+      if (block.endTime <= startTime) continue;
+      if (block.startTime >= startTime + maxDuration) break;
+      startTime = block.endTime;
+    }
+    const next = this.blocks.find((b) => b.startTime >= startTime);
+    const available = next ? next.startTime - startTime : Infinity;
+    return { startTime, duration: Math.min(maxDuration, available) };
   }
+
+  // the blocks either side of the given one in time, which bound its move and
+  // resize range
+  private neighborsOf = (block: Block) => {
+    let previous: Block | null = null;
+    let next: Block | null = null;
+    for (const other of this.blocks) {
+      if (other === block) continue;
+      if (other.startTime < block.startTime) {
+        if (!previous || other.startTime > previous.startTime) previous = other;
+      } else if (!next || other.startTime < next.startTime) next = other;
+    }
+    return { previous, next };
+  };
 
   attemptMoveBlock = (block: Block, desiredTime: number, relative = false) => {
     if (block.layer != this || block.locked) return;
-    block.startTime = relative ? desiredTime + block.startTime : desiredTime;
+
+    const desiredStartTime = relative ? block.startTime + desiredTime : desiredTime;
+    const { previous, next } = this.neighborsOf(block);
+    const lowerBound = previous?.endTime ?? 0;
+    const upperBound = (next?.startTime ?? Infinity) - block.duration;
+    if (upperBound < lowerBound) return;
+
+    block.startTime = Math.min(Math.max(desiredStartTime, lowerBound), upperBound);
+    // start time decides position in the chain's ordering
+    this.blocks.splice(this.blocks.indexOf(block), 1);
+    this.addBlock(block);
   };
 
   resizeBlockLeftBound = (block: Block, delta: number) => {
@@ -248,14 +285,10 @@ export class EffectChain implements Layer {
     const desiredStartTime = block.startTime + delta;
     if (desiredStartTime >= block.endTime) return;
 
-    if (desiredStartTime < 0) {
-      block.duration = block.endTime;
-      block.startTime = 0;
-      return;
-    }
-
-    block.startTime += delta;
-    block.duration -= delta;
+    const lowerBound = this.neighborsOf(block).previous?.endTime ?? 0;
+    const startTime = Math.max(desiredStartTime, lowerBound);
+    block.duration = block.endTime - startTime;
+    block.startTime = startTime;
   };
 
   resizeBlockRightBound = (block: Block, delta: number) => {
@@ -264,7 +297,8 @@ export class EffectChain implements Layer {
     const desiredEndTime = block.endTime + delta;
     if (desiredEndTime <= block.startTime) return;
 
-    block.duration += delta;
+    const upperBound = this.neighborsOf(block).next?.startTime ?? Infinity;
+    block.duration = Math.min(desiredEndTime, upperBound) - block.startTime;
   };
 
   // Chain blocks are applied in series rather than summed, so there is no

--- a/src/types/EffectChain.ts
+++ b/src/types/EffectChain.ts
@@ -1,0 +1,279 @@
+import { makeAutoObservable, runInAction } from "mobx";
+import type { Store } from "@/src/types/Store";
+import type { Layer } from "@/src/types/Layer";
+import { Block } from "@/src/types/Block";
+import type { Pattern } from "@/src/types/Pattern";
+import type { Variation } from "@/src/types/Variations/Variation";
+import { generateId } from "@/src/utils/id";
+import { DEFAULT_BLOCK_DURATION } from "@/src/utils/time";
+import { defaultEffectMap } from "@/src/effects/effects";
+
+// used for a block's lane until its actual rendered height is reported
+const UNMEASURED_BLOCK_HEIGHT = 50;
+
+/**
+ * An ordered chain of effect blocks applied to already-composited output —
+ * either one layer's merged blocks or the entire layer stack. Position in
+ * `blocks` is signal order; each block's start time and duration decide when it
+ * is in the signal path at all.
+ *
+ * It implements Layer so that the timeline's block components (drag, resize,
+ * selection, automation lanes) drive chain blocks through the same code paths
+ * they use for pattern blocks. A chain is never in `store.layers`, so it never
+ * composites as a layer.
+ */
+export class EffectChain implements Layer {
+  id = generateId();
+  name: string;
+  // editor-only bypass: false takes the whole chain out of the signal path
+  visible = true;
+  // satisfies Layer; a chain strip has no collapsed state of its own
+  collapsed = false;
+
+  blocks: Block[] = [];
+
+  // rendered block heights in px, reported from the DOM as blocks
+  // mount/resize (see reportBlockHeight)
+  blockHeights = new Map<string, number>();
+
+  _activeBlocks: Block[] = [];
+
+  // Buffered height reports, applied together once per frame. Deliberately not
+  // observable — this is bookkeeping for the flush, not state anything renders.
+  _pendingHeights = new Map<string, number>();
+  _heightFlushHandle: number | null = null;
+
+  constructor(
+    readonly store: Store,
+    name: string,
+  ) {
+    this.name = name;
+    makeAutoObservable(this, {
+      store: false,
+      _activeBlocks: false,
+      _pendingHeights: false,
+      _heightFlushHandle: false,
+    });
+  }
+
+  /**
+   * The blocks in the signal path at the playhead, in chain order.
+   *
+   * The array identity is held stable while the membership is unchanged, so the
+   * render pipeline's observers see an unchanged computed value and don't
+   * re-render on every frame the playhead advances.
+   */
+  get activeBlocks(): Block[] {
+    const { globalTime } = this.store.audioStore;
+    const active = this.visible
+      ? this.blocks.filter(
+          (block) => block.startTime <= globalTime && globalTime < block.endTime,
+        )
+      : [];
+
+    const previous = this._activeBlocks;
+    if (
+      active.length === previous.length &&
+      active.every((block, i) => block === previous[i])
+    )
+      return previous;
+
+    this._activeBlocks = active;
+    return active;
+  }
+
+  // Overlapping blocks are displayed stacked in "lanes" within the chain strip.
+  // Greedy interval partitioning: in start time order, each block goes into the
+  // first lane whose previous block has ended.
+  get blockLanes(): Map<string, number> {
+    const sorted = this.blocks
+      .slice()
+      .sort((a, b) => a.startTime - b.startTime || a.id.localeCompare(b.id));
+    const laneEndTimes: number[] = [];
+    const lanes = new Map<string, number>();
+    for (const block of sorted) {
+      let lane = laneEndTimes.findIndex((end) => end <= block.startTime);
+      if (lane === -1) {
+        lane = laneEndTimes.length;
+        laneEndTimes.push(0);
+      }
+      laneEndTimes[lane] = block.endTime;
+      lanes.set(block.id, lane);
+    }
+    return lanes;
+  }
+
+  // each lane is exactly as tall as its tallest block
+  get laneHeights(): number[] {
+    let laneCount = 0;
+    for (const lane of this.blockLanes.values())
+      laneCount = Math.max(laneCount, lane + 1);
+
+    const heights = Array(laneCount).fill(UNMEASURED_BLOCK_HEIGHT);
+    for (const [blockId, lane] of this.blockLanes) {
+      heights[lane] = Math.max(
+        heights[lane],
+        this.blockHeights.get(blockId) ?? UNMEASURED_BLOCK_HEIGHT,
+      );
+    }
+    return heights;
+  }
+
+  // An empty chain takes up no vertical space at all, so a layer with no effect
+  // chain lays out exactly as it would without the feature.
+  get height() {
+    return this.laneHeights.reduce((sum, laneHeight) => sum + laneHeight, 0);
+  }
+
+  blockTopOffset = (block: Block) => {
+    const lane = this.blockLanes.get(block.id) ?? 0;
+    // Blocks in the first lane are always at the top, so return before reading
+    // laneHeights: touching it would subscribe them to every block's measured
+    // height and re-render them whenever any block in the chain resizes.
+    if (lane === 0) return 0;
+    return this.laneHeights
+      .slice(0, lane)
+      .reduce((sum, laneHeight) => sum + laneHeight, 0);
+  };
+
+  // See LayerV2.reportBlockHeight for why a frame's worth of reports is batched
+  // into a single observable write.
+  reportBlockHeight = (block: Block, heightPx: number) => {
+    if (
+      this.blockHeights.get(block.id) === heightPx &&
+      !this._pendingHeights.has(block.id)
+    )
+      return;
+
+    this._pendingHeights.set(block.id, heightPx);
+    if (this._heightFlushHandle !== null) return;
+    if (typeof window === "undefined") {
+      this.flushBlockHeights();
+      return;
+    }
+    this._heightFlushHandle = window.requestAnimationFrame(() =>
+      this.flushBlockHeights(),
+    );
+  };
+
+  private flushBlockHeights = () => {
+    this._heightFlushHandle = null;
+    if (this._pendingHeights.size === 0) return;
+    const pending = this._pendingHeights;
+    this._pendingHeights = new Map();
+    runInAction(() => {
+      for (const [blockId, heightPx] of pending)
+        this.blockHeights.set(blockId, heightPx);
+    });
+  };
+
+  toggleVisible = () => {
+    this.visible = !this.visible;
+  };
+
+  // Append an effect to the end of the chain, playing from the playhead.
+  addCloneOfEffect = (effect: Pattern) => {
+    const block = new Block(this.store, effect.clone());
+    block.setTiming({
+      startTime: this.store.audioStore.globalTime,
+      duration: DEFAULT_BLOCK_DURATION,
+    });
+    this.addBlock(block);
+    return block;
+  };
+
+  addBlock = (block: Block) => {
+    block.layer = this;
+    block.inEffectChain = true;
+    this.blocks.push(block);
+  };
+
+  removeBlock = (block: Block) => {
+    const index = this.blocks.indexOf(block);
+    if (index === -1) return;
+    this.blocks.splice(index, 1);
+    block.layer = null;
+    block.inEffectChain = false;
+  };
+
+  // Move a block `delta` positions along the chain, changing the order its
+  // effect is applied in.
+  reorderBlock = (block: Block, delta: number) => {
+    const index = this.blocks.indexOf(block);
+    if (index < 0) return;
+
+    const newIndex = index + delta;
+    if (newIndex < 0 || newIndex >= this.blocks.length) return;
+
+    this.blocks.splice(index, 1);
+    this.blocks.splice(newIndex, 0, block);
+  };
+
+  // Only effects belong in a chain, so a pattern block dropped here is ignored.
+  insertCloneOfBlock = (block: Block) => {
+    if (!defaultEffectMap[block.pattern.name]) return;
+    const clone = block.clone();
+    clone.regenerateId();
+    clone.setTiming({
+      startTime: this.store.audioStore.globalTime,
+      duration: block.duration,
+    });
+    this.addBlock(clone);
+  };
+
+  getAllBlocks() {
+    return this.blocks.slice();
+  }
+
+  getNextValidStartAndDuration(fromTime: number, maxDuration: number) {
+    return { startTime: fromTime, duration: maxDuration };
+  }
+
+  attemptMoveBlock = (block: Block, desiredTime: number, relative = false) => {
+    if (block.layer != this || block.locked) return;
+    block.startTime = relative ? desiredTime + block.startTime : desiredTime;
+  };
+
+  resizeBlockLeftBound = (block: Block, delta: number) => {
+    if (block.layer != this || block.locked) return;
+
+    const desiredStartTime = block.startTime + delta;
+    if (desiredStartTime >= block.endTime) return;
+
+    if (desiredStartTime < 0) {
+      block.duration = block.endTime;
+      block.startTime = 0;
+      return;
+    }
+
+    block.startTime += delta;
+    block.duration -= delta;
+  };
+
+  resizeBlockRightBound = (block: Block, delta: number) => {
+    if (block.layer != this || block.locked) return;
+
+    const desiredEndTime = block.endTime + delta;
+    if (desiredEndTime <= block.startTime) return;
+
+    block.duration += delta;
+  };
+
+  // Chain blocks are applied in series rather than summed, so there is no
+  // crossfade between them to derive.
+  autoBlockOpacityAt = () => 1;
+  autoOpacityVariations = (): Variation<number>[] | null => null;
+
+  serialize = () => ({
+    id: this.id,
+    blocks: this.blocks.map((block) => block.serialize()),
+  });
+
+  static deserialize = (store: Store, name: string, data: any) => {
+    const chain = new EffectChain(store, name);
+    if (data?.id) chain.id = data.id;
+    for (const blockData of data?.blocks ?? [])
+      chain.addBlock(Block.deserialize(store, blockData));
+    return chain;
+  };
+}

--- a/src/types/EffectChain.ts
+++ b/src/types/EffectChain.ts
@@ -5,7 +5,10 @@ import { Block } from "@/src/types/Block";
 import type { Pattern } from "@/src/types/Pattern";
 import type { Variation } from "@/src/types/Variations/Variation";
 import { generateId } from "@/src/utils/id";
-import { DEFAULT_BLOCK_DURATION } from "@/src/utils/time";
+import {
+  DEFAULT_BLOCK_DURATION,
+  MINIMUM_VARIATION_DURATION,
+} from "@/src/utils/time";
 import { EffectChainSource } from "@/src/patterns/EffectChainSource";
 
 // used for a block's lane until its actual rendered height is reported
@@ -238,14 +241,24 @@ export class EffectChain implements Layer {
   // The first gap at or after fromTime that no block occupies. Chain blocks
   // apply in series to the same composited input, so overlapping them would
   // leave their order to something the timeline cannot show.
+  /**
+   * Where a block added at fromTime goes, and how long it can be.
+   *
+   * A gap too short for the requested duration shortens the block instead of
+   * moving it: a short block at the playhead is far closer to what was asked
+   * for than a full-length one somewhere the playhead isn't. The start moves
+   * only when the playhead has no room at all — inside a block, or in a gap too
+   * small to hold one.
+   */
   getNextValidStartAndDuration(fromTime: number, maxDuration: number) {
     let startTime = fromTime;
     for (const block of this.blocks) {
       if (block.endTime <= startTime) continue;
-      if (block.startTime >= startTime + maxDuration) break;
+      if (block.startTime - startTime >= MINIMUM_VARIATION_DURATION) break;
       startTime = block.endTime;
     }
-    const next = this.blocks.find((b) => b.startTime >= startTime);
+
+    const next = this.blocks.find((b) => b.startTime > startTime);
     const available = next ? next.startTime - startTime : Infinity;
     return { startTime, duration: Math.min(maxDuration, available) };
   }

--- a/src/types/EffectChain.ts
+++ b/src/types/EffectChain.ts
@@ -67,7 +67,8 @@ export class EffectChain implements Layer {
     const { globalTime } = this.store.audioStore;
     const active = this.visible
       ? this.blocks.filter(
-          (block) => block.startTime <= globalTime && globalTime < block.endTime,
+          (block) =>
+            block.startTime <= globalTime && globalTime < block.endTime,
         )
       : [];
 

--- a/src/types/Layer/LayerV1.ts
+++ b/src/types/Layer/LayerV1.ts
@@ -5,6 +5,7 @@ import { makeAutoObservable } from "mobx";
 import { generateId } from "@/src/utils/id";
 import { Layer } from ".";
 import { Block } from "@/src/types/Block";
+import { EffectChain } from "@/src/types/EffectChain";
 
 export type ActivePatternsWindow = {
   startTime: number;
@@ -20,16 +21,24 @@ export class LayerV1 implements Layer {
   // interface compliance; collapse is a V2/editor feature (see Layer.collapsed)
   collapsed = false;
 
+  effectChain: EffectChain;
+
   patternBlocks: Block[] = [];
   _lastComputedCurrentBlock: Block | null = null;
 
   constructor(readonly store: Store) {
+    this.effectChain = new EffectChain(store, "Layer effects");
     makeAutoObservable(this, {
       store: false,
 
       // don't make this observable, since it's just a cache
       _lastComputedCurrentBlock: false,
     });
+  }
+
+  // a v1 layer stacks nothing beneath its blocks, so its whole row is theirs
+  get blockLanesHeight() {
+    return this.height;
   }
 
   // returns the block that the global time is inside of, or null if none

--- a/src/types/Layer/LayerV2.ts
+++ b/src/types/Layer/LayerV2.ts
@@ -5,6 +5,7 @@ import { makeAutoObservable, runInAction } from "mobx";
 import { generateId } from "@/src/utils/id";
 import { Layer } from ".";
 import { BlockMap } from "../BlockMap";
+import { EffectChain } from "@/src/types/EffectChain";
 import { Variation } from "@/src/types/Variations/Variation";
 import { EasingVariation } from "@/src/types/Variations/EasingVariation";
 import { CurveVariation } from "@/src/types/Variations/CurveVariation";
@@ -29,6 +30,10 @@ export class LayerV2 implements Layer {
 
   blockMap = new BlockMap();
 
+  // effects applied to this layer's merged output, after all of its blocks have
+  // been composited together
+  effectChain: EffectChain;
+
   _lastComputedWindowStartTime: number = -1;
   _maxConcurrentBlocks: number | null = null;
   _activeBlocks: Block[] = [];
@@ -39,6 +44,7 @@ export class LayerV2 implements Layer {
   _heightFlushHandle: number | null = null;
 
   constructor(readonly store: Store) {
+    this.effectChain = new EffectChain(store, "Layer effects");
     makeAutoObservable(this, {
       store: false,
       _lastComputedWindowStartTime: false,
@@ -123,9 +129,15 @@ export class LayerV2 implements Layer {
     return heights;
   }
 
+  // Height of the block lanes alone. The effect chain strip sits directly below
+  // them, so this is where it starts.
+  get blockLanesHeight() {
+    return this.laneHeights.reduce((sum, laneHeight) => sum + laneHeight, 0);
+  }
+
   get height() {
     if (this.collapsed) return COLLAPSED_LAYER_HEIGHT;
-    return this.laneHeights.reduce((sum, laneHeight) => sum + laneHeight, 0);
+    return this.blockLanesHeight + this.effectChain.height;
   }
 
   blockTopOffset = (block: Block) => {
@@ -300,6 +312,10 @@ export class LayerV2 implements Layer {
   };
 
   removeBlock = (block: Block) => {
+    if (block.inEffectChain) {
+      this.effectChain.removeBlock(block);
+      return;
+    }
     this.blockMap.removeBlock(block);
     block.layer = null;
   };
@@ -362,6 +378,7 @@ export class LayerV2 implements Layer {
     id: this.id,
     name: this.name,
     blockMap: this.blockMap.serialize(),
+    effectChain: this.effectChain.serialize(),
   });
 
   static deserialize = (store: Store, data: any) => {
@@ -370,6 +387,11 @@ export class LayerV2 implements Layer {
     layer.name = data.name ?? "";
 
     layer.blockMap = BlockMap.deserialize(store, layer, data.blockMap);
+    layer.effectChain = EffectChain.deserialize(
+      store,
+      "Layer effects",
+      data.effectChain,
+    );
     return layer;
   };
 }

--- a/src/types/Layer/index.ts
+++ b/src/types/Layer/index.ts
@@ -1,5 +1,6 @@
 import type { Store } from "@/src/types/Store";
 import { Block } from "@/src/types/Block";
+import type { EffectChain } from "@/src/types/EffectChain";
 import type { Variation } from "@/src/types/Variations/Variation";
 
 export type ActivePatternsWindow = {
@@ -17,6 +18,11 @@ export type Layer = {
   // controls whether the layer renders to the canopy. Not serialized.
   collapsed: boolean;
   height: number;
+  // height of the blocks alone, without the effect chain strip beneath them
+  blockLanesHeight: number;
+  // effects applied to everything the layer composites. Null only on an effect
+  // chain itself, which is what makes a chain a leaf rather than a nesting point.
+  effectChain: EffectChain | null;
   store: Store;
 
   insertCloneOfBlock(block: Block): void;

--- a/src/types/Store.ts
+++ b/src/types/Store.ts
@@ -20,6 +20,7 @@ import { Context, Role } from "@/src/types/context";
 import "@/src/utils/mobx";
 import { UserStore } from "@/src/types/UserStore";
 import { LayerV2 } from "./Layer/LayerV2";
+import { EffectChain } from "@/src/types/EffectChain";
 import { migrateV1ExperienceData } from "@/src/utils/migrateV1ExperienceData";
 import { migrateSequenceToRegions } from "@/src/utils/migrateVariations";
 import { User } from "@/src/types/User";
@@ -94,6 +95,10 @@ export class Store {
   userStore = new UserStore(this);
 
   layers: Layer[] = [];
+
+  // effects applied to the whole rendered frame, after every layer has been
+  // merged together
+  globalEffectChain: EffectChain = new EffectChain(this, "Global effects");
 
   sendingData = false;
   viewerMode = false;
@@ -173,12 +178,17 @@ export class Store {
     const index = this.layers.indexOf(layer);
     if (index === -1) return;
 
+    // a block of the layer's effect chain points at the chain, not the layer
+    const belongsToLayer = (block: Block) =>
+      block.layer === layer ||
+      (layer instanceof LayerV2 && block.layer === layer.effectChain);
+
     this.selectedBlocksOrVariations = new Set(
       Array.from(this.selectedBlocksOrVariations).filter(
-        (selection) => selection.block.layer !== layer,
+        (selection) => !belongsToLayer(selection.block),
       ),
     );
-    if (this.selectedParameter?.block.layer === layer)
+    if (this.selectedParameter && belongsToLayer(this.selectedParameter.block))
       this.selectedParameter = null;
 
     this.layers.splice(index, 1);
@@ -668,6 +678,9 @@ export class Store {
       if (blockOrVariation.type === "block") {
         // TODO: better generalize for multiple layers
         this.layers.forEach((l) => l.removeBlock(blockOrVariation.block));
+        // effect chains are not in this.layers, so a block in one is removed
+        // through its own back-reference
+        blockOrVariation.block.layer?.removeBlock(blockOrVariation.block);
         blockRemoved = true;
       } else if (blockOrVariation.type === "variation")
         this.deleteVariation(
@@ -930,7 +943,10 @@ export class Store {
       song: this.audioStore.selectedSong,
       status: this.experienceStatus,
       version: this.experienceVersion,
-      data: { layers: this.layers.map((l) => l.serialize()) },
+      data: {
+        layers: this.layers.map((l) => l.serialize()),
+        globalEffectChain: this.globalEffectChain.serialize(),
+      },
       thumbnailURL: this.experienceThumbnailURL,
     };
   };
@@ -951,6 +967,11 @@ export class Store {
         : experience.data;
     this.experienceVersion = EXPERIENCE_VERSION;
     this.layers = data.layers.map((l: any) => LayerV2.deserialize(this, l));
+    this.globalEffectChain = EffectChain.deserialize(
+      this,
+      "Global effects",
+      data.globalEffectChain,
+    );
 
     // Select first layer
     this.selectedLayer = this.layers[0];
@@ -984,7 +1005,11 @@ export class Store {
       // PARENT pattern block's timeline, so span them to the parent's duration.
       (block.effectBlocks ?? []).forEach((eff) => convert(eff, laneDuration));
     };
-    for (const layer of this.layers)
+    for (const layer of this.layers) {
       layer.getAllBlocks().forEach((b) => convert(b, b.duration));
+      if (layer instanceof LayerV2)
+        layer.effectChain.blocks.forEach((b) => convert(b, b.duration));
+    }
+    this.globalEffectChain.blocks.forEach((b) => convert(b, b.duration));
   };
 }

--- a/src/types/Store.ts
+++ b/src/types/Store.ts
@@ -185,7 +185,7 @@ export class Store {
     // a block of the layer's effect chain points at the chain, not the layer
     const belongsToLayer = (block: Block) =>
       block.layer === layer ||
-      (layer instanceof LayerV2 && block.layer === layer.effectChain);
+      (!!layer.effectChain && block.layer === layer.effectChain);
 
     this.selectedBlocksOrVariations = new Set(
       Array.from(this.selectedBlocksOrVariations).filter(
@@ -1011,8 +1011,7 @@ export class Store {
     };
     for (const layer of this.layers) {
       layer.getAllBlocks().forEach((b) => convert(b, b.duration));
-      if (layer instanceof LayerV2)
-        layer.effectChain.blocks.forEach((b) => convert(b, b.duration));
+      layer.effectChain?.blocks.forEach((b) => convert(b, b.duration));
     }
     this.globalEffectChain.blocks.forEach((b) => convert(b, b.duration));
   };

--- a/src/types/Store.ts
+++ b/src/types/Store.ts
@@ -140,6 +140,10 @@ export class Store {
     return this._selectedLayer;
   }
   set selectedLayer(value: Layer) {
+    // Effect chains are Layers so the timeline can drive their blocks, but they
+    // hold effects only — selecting one as the layer to add patterns to would
+    // silently drop them.
+    if (value instanceof EffectChain) return;
     if (this._selectedLayer === value) return;
     this._selectedLayer = value;
   }
@@ -699,7 +703,7 @@ export class Store {
 
   addVariation = (block: Block, uniformName: string, variation: Variation) => {
     block.addVariation(uniformName, variation);
-    if (block.layer) this._selectedLayer = block.layer;
+    if (block.layer) this.selectedLayer = block.layer;
     this.selectVariation(block, uniformName, variation);
   };
 

--- a/src/utils/patternsEffects.ts
+++ b/src/utils/patternsEffects.ts
@@ -1,12 +1,15 @@
 import { defaultPatternMap } from "@/src/patterns/patterns";
 import { defaultEffectMap } from "@/src/effects/effects";
 import { Opacity } from "@/src/patterns/Opacity";
+import { EffectChainSource } from "@/src/patterns/EffectChainSource";
 import { Pattern } from "@/src/types/Pattern";
 
 const opacityPattern = Opacity();
+const effectChainSourcePattern = EffectChainSource();
 
 export const defaultPatternEffectMap: Record<string, Pattern> = {
   ...defaultPatternMap,
   ...defaultEffectMap,
   [opacityPattern.name]: opacityPattern,
+  [effectChainSourcePattern.name]: effectChainSourcePattern,
 };


### PR DESCRIPTION
Effects can only be attached to one pattern block at a time today. This adds two more places they can live: a chain on a layer, which processes everything that layer composites, and a global chain, which processes the whole frame after all layers merge.

Existing effects work as-is at this level — an effect just samples a texture, and a composited layer is one. A chain block carries its own start time and duration and holds the effects that apply while the playhead is inside it, which is the same relationship a pattern block has with its effect chain. So chain blocks pick up dragging, resizing, parameter lanes and variations from the machinery that's already there.

In the timeline, each layer gets a thin strip beneath its blocks and there's a pinned "Global FX" row under the layer stack. Effects are added from the wand menu in the layer header or the global row.

## What changed

- **`EffectChain`** (new) — the effects applied to composited output. A chain holds blocks the way a layer does, and each block holds a stack of effects the way a pattern block does: the block owns the time bounds, the effects inside share them and run in the order they are stacked. Blocks never overlap, so the chain's own order is purely chronological. It implements `Layer`, which is the load-bearing decision: the timeline's existing block components drive everything through `block.layer`, so chain blocks get drag, resize, selection and automation lanes with no special cases. A chain is never in `store.layers`, so it never composites as a layer.
- **`EffectChainNode`** (new) — shared render node that runs a list of effects between a source and destination target, alternating outputs so the last pass lands in the destination. `BlockStackNode` delegates its own effect chain to it instead of hand-rolling the target swap.
- **`RenderPipelineV2`** — both merge sites, per-layer and cross-layer, are wrapped in `MergeThroughEffectChain`. With no effects in the signal path the merge writes its destination directly, and only a populated chain allocates the two scratch targets it needs. Layer chains run at the layer's priority band + 6,000; the global chain at 1,100,000.
- **Model and serialization** — `LayerV2` gains `effectChain` and `Store` gains `globalEffectChain`, both serialized alongside existing data. A missing field deserializes to an empty chain, so existing experiences round-trip unchanged. A chain block's source is the `EffectChainSource` pattern, registered like `Opacity` so it round-trips without special-casing.
- **`Layer` interface** — declares `effectChain` and `blockLanesHeight`, so call sites reach a layer's chain directly instead of narrowing to a concrete layer class.
- **Timeline** — `TimelineEffectChainStrip` beneath each layer's blocks, a pinned `GlobalEffectRow`, and `AddChainEffectMenu` behind the wand button in both. An empty chain has zero height, so existing layouts are unchanged.
- **Device panel** — a chain block gets the same view a pattern block gets: its own effects, left to right, with the chain's composited input standing where the pattern would be. Reordering there reorders the signal path.
- **`Block.opacityApplies`** — opacity is applied by the merge shader where a block's output joins its siblings, and an effect never reaches a merge, so effect blocks no longer show an opacity dot, edge ramp, or automation lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Layer level effects (original pattern / with layer effect applies / with layer effects bypassed)

<img width="1265" height="760" alt="Screenshot 2026-08-16 at 1 31 46 PM" src="https://github.com/user-attachments/assets/1d855089-881b-4fd9-86da-de4e090448cb" />
<img width="1264" height="779" alt="Screenshot 2026-08-16 at 1 32 59 PM" src="https://github.com/user-attachments/assets/0ab12df8-1334-4a6f-b5db-248ffde6c7f2" />
<img width="1268" height="785" alt="Screenshot 2026-08-16 at 1 33 06 PM" src="https://github.com/user-attachments/assets/d67bc0f1-1125-46f2-837d-c9edff563432" />

Global effects (original / applied / bypassed)

<img width="1264" height="781" alt="Screenshot 2026-08-16 at 1 34 18 PM" src="https://github.com/user-attachments/assets/80073230-9336-4e4e-b6f4-ff64d85c0ff0" />
<img width="1271" height="775" alt="Screenshot 2026-08-16 at 1 34 41 PM" src="https://github.com/user-attachments/assets/ee95af7f-f82e-4278-b87f-74bc33860e25" />
<img width="1269" height="784" alt="Screenshot 2026-08-16 at 1 34 50 PM" src="https://github.com/user-attachments/assets/bc60b4e5-5cfe-4fc6-bd2b-bc2d6fd218d1" />



